### PR TITLE
Support semicolon as a string list separator

### DIFF
--- a/src/jail_rules.c
+++ b/src/jail_rules.c
@@ -58,6 +58,7 @@ static const char DESKTOP_KEY_DESKTOP_ENTRY_TYPE[] = "Type";
 static const char DESKTOP_ENTRY_TYPE_APPLICATION[] = "Application";
 
 static const char SAILJAIL_SECTION_DEFAULT[] = DEFAULT_PROFILE_SECTION;
+static const char SAILJAIL_LIST_SEPARATORS[] = ":;,";
 
 static const char SAILJAIL_KEY_PERMS[] = "Permissions";
 #define SAILJAIL_KEY_PERM_REQUIRED '!'
@@ -483,7 +484,7 @@ jail_rules_parse_section(
     val = g_key_file_get_string(kf, section, SAILJAIL_KEY_PERMS, NULL);
     if (val) {
         JAIL_PERMIT_TYPE permit;
-        char** vals = g_strsplit_set(val, ":,", -1);
+        char** vals = g_strsplit_set(val, SAILJAIL_LIST_SEPARATORS, -1);
         char** ptr = vals;
 
         for (ptr = vals; *ptr; ptr++) {
@@ -515,7 +516,7 @@ jail_rules_parse_section(
     /* FileAccess= */
     val = g_key_file_get_string(kf, section, SAILJAIL_KEY_FILE_ACCESS, NULL);
     if (val) {
-        char** vals = g_strsplit_set(val, ":,", -1);
+        char** vals = g_strsplit_set(val, SAILJAIL_LIST_SEPARATORS, -1);
         char** ptr = vals;
 
         for (ptr = vals; *ptr; ptr++) {

--- a/unit/test_rules/test_rules.c
+++ b/unit/test_rules/test_rules.c
@@ -432,11 +432,12 @@ test_basic2(
     /*
      * Required Privileged overrides the optional one,
      * but optional Base doesn't overrides the implicit required one.
+     * Also test all possible list separators (:;,)
      */
     static const char profile_data[] =
         "[Section]\n" /* Lonely ? and - are ignored */
-        "Permissions = ?, ? Base, ? Test, ? Privileged, ! Privileged\n"
-        "FileAccess = ?, -, /tmp, /tmp\n" /* Only one path remains */
+        "Permissions = ?: ? Base; ? Test, ? Privileged, ! Privileged\n"
+        "FileAccess = ?: -, /tmp; /tmp\n" /* Only one path remains */
         "DBusUserOwn = foo.bar, ."; /* . is an invalid name and is ignored */
 
     g_assert(g_file_set_contents(profile, profile_data, -1, NULL));


### PR DESCRIPTION
It's the default one used by GKeyFile, there's no reason to not support it.