### PR TITLE
Export jail_rules_keyfile_parse() to plugins

### DIFF
--- a/include/jail_rules.h
+++ b/include/jail_rules.h
@@ -98,6 +98,13 @@ jail_rules_permit_parse(
     SAILJAIL_EXPORT;
 
 JailRules*
+jail_rules_keyfile_parse(
+    SailJail* jail,
+    GKeyFile* keyfile,
+    const char* section,
+    const char* app); /* Since 1.0.2 */
+
+JailRules*
 jail_rules_ref(
     JailRules* rules)
     SAILJAIL_EXPORT;

--- a/src/jail_launch.h
+++ b/src/jail_launch.h
@@ -39,19 +39,19 @@
 
 #include "jail_types_p.h"
 
-SailJail*
-jail_launch_new(
+JailLaunchHooks*
+jail_launch_hooks_new(
     void)
     JAIL_INTERNAL;
 
 void
-jail_launch_free(
-    SailJail* jail)
+jail_launch_hooks_free(
+    JailLaunchHooks* hooks)
     JAIL_INTERNAL;
 
 JailRules*
 jail_launch_confirm(
-    SailJail* jail,
+    JailLaunchHooks* hooks,
     const JailApp* app,
     const JailCmdLine* cmd,
     const JailRunUser* user,
@@ -60,7 +60,7 @@ jail_launch_confirm(
 
 void
 jail_launch_confirmed(
-    SailJail* jail,
+    JailLaunchHooks* hooks,
     const JailApp* app,
     const JailCmdLine* cmd,
     const JailRunUser* user,
@@ -69,7 +69,7 @@ jail_launch_confirmed(
 
 void
 jail_launch_denied(
-    SailJail* jail,
+    JailLaunchHooks* hooks,
     const JailApp* app,
     const JailCmdLine* cmd,
     const JailRunUser* user)

--- a/src/jail_rules_p.h
+++ b/src/jail_rules_p.h
@@ -54,6 +54,7 @@ jail_rules_new(
     const JailConf* conf,
     const JailRulesOpt* opt,
     char** profile_path,
+    char** section,
     GError** error)
     JAIL_INTERNAL;
 

--- a/src/jail_types_p.h
+++ b/src/jail_types_p.h
@@ -42,6 +42,12 @@
 #include <jail_types.h>
 
 typedef struct jail_conf JailConf;
+typedef struct jail_launch_hooks JailLaunchHooks;
+
+struct jail_fish {
+    JailLaunchHooks* hooks;
+    const JailConf* conf;
+};
 
 /* Macros */
 #define JAIL_INTERNAL G_GNUC_INTERNAL


### PR DESCRIPTION
To avoid duplicating the parsing logic.

Also, always pass the actually used section to `jail_launch_confirm()`. Plugins may assume that section is never NULL.