### PR TITLE
Passthrough mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,13 @@ TEST_SRC = \
   jail_rules.c
 
 SRC = $(TEST_SRC) \
-  jail_run.c \
+  jail_free.c \
   sailjail.c
+
+HAVE_FIREJAIL ?= 1
+ifneq ($(HAVE_FIREJAIL),0)
+SRC += jail_run.c
+endif
 
 #
 # Directories
@@ -76,7 +81,8 @@ RELEASE_FLAGS =
 COVERAGE_FLAGS = -g
 RELEASE_DEFS =
 WARNINGS = -Wall -Wstrict-aliasing -Wunused-result
-DEFINES += -DDEFAULT_PLUGIN_DIR='"$(DEFAULT_PLUGIN_DIR)"'
+DEFINES += -DDEFAULT_PLUGIN_DIR='"$(DEFAULT_PLUGIN_DIR)"' \
+  -DHAVE_FIREJAIL=$(HAVE_FIREJAIL)
 INCLUDES = -I$(SRC_DIR) -I$(INCLUDE_DIR)
 FULL_CFLAGS = -fPIC $(CFLAGS) $(DEFINES) $(WARNINGS) $(INCLUDES) \
   -MMD -MP $(shell pkg-config --cflags $(PKGS))

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -9,8 +9,14 @@ Source0:  %{name}-%{version}.tar.bz2
 %define glib_version 2.44
 %define libglibutil_version 1.0.43
 
+%{!?jailfish: %define jailfish 1}
+%if %{jailfish}
 Requires: firejail
 Requires: xdg-dbus-proxy
+%else
+Provides: sailjail-launch-approval
+%endif
+
 Requires: glib2 >= %{glib_version}
 Requires: libglibutil >= %{libglibutil_version}
 
@@ -35,19 +41,25 @@ This package contains development files for %{name} plugins.
 %setup -q -n %{name}-%{version}
 
 %build
-make %{_smp_mflags} LIBDIR=%{_libdir} KEEP_SYMBOLS=1 release pkgconfig
+make %{_smp_mflags} \
+  LIBDIR=%{_libdir} \
+  KEEP_SYMBOLS=1 \
+  HAVE_FIREJAIL=%{jailfish} \
+  release pkgconfig
 
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} LIBDIR=%{_libdir} install install-dev
 
 %check
-make -C unit test
+make HAVE_FIREJAIL=%{jailfish} -C unit test
 
 %files
 %defattr(-,root,root,-)
 %dir %attr(755,root,root) %{permissions_dir}
+%if %{jailfish}
 %attr(6755,root,root) %{_bindir}/sailjail
+%endif
 %{_bindir}/sailjail
 %{permissions_dir}/*
 

--- a/src/jail_conf.c
+++ b/src/jail_conf.c
@@ -44,6 +44,7 @@
 #define DEFAULT_PROFILE_DIR "/etc/sailjail"
 #define DEFAULT_PERM_SUBDIR "permissions"
 #define DEFAULT_PERM_DIR DEFAULT_PROFILE_DIR "/" DEFAULT_PERM_SUBDIR
+#define DEFAULT_PASSTHROUGH FALSE
 
 #define SECTION "Settings"
 #define KEY_EXEC "Exec"
@@ -51,6 +52,7 @@
 #define KEY_DESKTOP_DIR "DesktopDir"
 #define KEY_PROFILE_DIR "ProfileDir"
 #define KEY_PERM_DIR "PermissionsDir"
+#define KEY_PASSTHROUGH "Passthrough"
 
 typedef struct jail_conf_priv {
     JailConf pub;
@@ -76,6 +78,8 @@ jail_conf_parse(
     JailConfPriv* priv)
 {
     JailConf* conf = &priv->pub;
+    GError* error = NULL;
+    gboolean b;
     char* str;
     char* perm_dir;
 
@@ -121,6 +125,14 @@ jail_conf_parse(
         conf->perm_dir = priv->perm_dir = perm_dir;
         GDEBUG("  %s=%s", KEY_PERM_DIR, conf->perm_dir);
     }
+
+    b = g_key_file_get_boolean(f, SECTION, KEY_PASSTHROUGH, &error);
+    if (error) {
+        g_error_free(error);
+    } else {
+        conf->passthrough = b;
+        GDEBUG("  %s=%s", KEY_PASSTHROUGH, b ? "true" : "false");
+    }
 }
 
 static
@@ -147,6 +159,7 @@ jail_conf_new(
     conf->desktop_dir = DEFAULT_DESKTOP_DIR;
     conf->profile_dir = DEFAULT_PROFILE_DIR;
     conf->perm_dir = DEFAULT_PERM_DIR;
+    conf->passthrough = DEFAULT_PASSTHROUGH;
     return conf;
 }
 

--- a/src/jail_conf.h
+++ b/src/jail_conf.h
@@ -52,6 +52,7 @@ struct jail_conf {              /* Defaults: */
     const char* desktop_dir;    /* /usr/share/applications */
     const char* profile_dir;    /* /etc/sailjail */
     const char* perm_dir;       /* /etc/sailjail/permission */
+    gboolean passthrough;       /* FALSE */
 };
 
 JailConf*

--- a/src/jail_free.h
+++ b/src/jail_free.h
@@ -34,30 +34,20 @@
  * any official policies, either expressed or implied.
  */
 
-#ifndef _JAIL_DEFS_H_
-#define _JAIL_DEFS_H_
+#ifndef _JAIL_FREE_H_
+#define _JAIL_FREE_H_
 
-#define SAILJAIL_EXPORT __attribute__((visibility ("default")))
+#include "jail_types_p.h"
 
-#include <jail_types.h>
+void
+jail_free(
+    int argc,
+    char* argv[],
+    const JailCreds* creds,
+    GError** error)
+    JAIL_INTERNAL;
 
-typedef struct jail_conf JailConf;
-typedef struct jail_creds JailCreds;
-typedef struct jail_launch_hooks JailLaunchHooks;
-
-struct jail_fish {
-    JailLaunchHooks* hooks;
-    const JailConf* conf;
-};
-
-/* Macros */
-#define JAIL_INTERNAL G_GNUC_INTERNAL
-
-#ifndef HAVE_FIREJAIL
-#  define HAVE_FIREJAIL 1
-#endif
-
-#endif /* _JAIL_DEFS_H_ */
+#endif /* _JAIL_FREE_H_ */
 
 /*
  * Local Variables:

--- a/src/jail_run.c
+++ b/src/jail_run.c
@@ -241,8 +241,8 @@ jail_run(
         opt = g_strdup_printf(FIREJAIL_DBUS_LOG_OPT_FMT, trace_dir);
         g_ptr_array_add(args, opt);
         g_ptr_array_add(args_alloc, opt);
-        g_ptr_array_add(args, FIREJAIL_DBUS_SYSTEM_LOG);
-        g_ptr_array_add(args, FIREJAIL_DBUS_USER_LOG);
+        g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_SYSTEM_LOG);
+        g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_USER_LOG);
     }
 
     /* 3. Done with firejail options */

--- a/unit/common/Makefile
+++ b/unit/common/Makefile
@@ -10,6 +10,8 @@ ifndef EXE
 ${error EXE not defined}
 endif
 
+HAVE_FIREJAIL ?= 1
+
 SRC ?= $(EXE).c
 COMMON_SRC ?= test_common.c
 
@@ -44,6 +46,7 @@ COVERAGE_BUILD_DIR = $(BUILD_DIR)/coverage
 CC = $(CROSS_COMPILE)gcc
 LD = $(CC)
 WARNINGS += -Wall
+DEFINES += -DHAVE_FIREJAIL=$(HAVE_FIREJAIL)
 INCLUDES += -I$(COMMON_DIR) -I$(LIB_DIR)/src -I$(LIB_DIR)/include
 BASE_FLAGS = -fPIC
 BASE_LDFLAGS = $(BASE_FLAGS) $(LDFLAGS)
@@ -175,10 +178,10 @@ $(COVERAGE_EXE): $(COVERAGE_LIB) $(COVERAGE_BUILD_DIR) $(COVERAGE_OBJS)
 	$(LD) $(COVERAGE_LDFLAGS) $(COVERAGE_OBJS) $< $(LIBS) -o $@
 
 debug_lib:
-	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) debug_test_lib
+	@$(MAKE) $(SUBMAKE_OPTS) -C $(LIB_DIR) debug_test_lib
 
 release_lib:
-	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) release_test_lib
+	@$(MAKE) $(SUBMAKE_OPTS) -C $(LIB_DIR) release_test_lib
 
 coverage_lib:
-	@make $(SUBMAKE_OPTS) -C $(LIB_DIR) coverage_test_lib
+	@$(MAKE) $(SUBMAKE_OPTS) -C $(LIB_DIR) coverage_test_lib


### PR DESCRIPTION
In this mode, sailjail directly launches the target program with the permissions of the parent process. The only way to enable this
mode is to add `Passthrough=true` to `/etc/sailjail.conf` file:
```ini
[Settings]
Passthrough=true
```
The default is obviously false.