### PR TITLE
[sailjail] Add jolla-camera-lockscreen to jolla-camera.profile. JB#51737

### DIFF
--- a/permissions/jolla-camera.profile
+++ b/permissions/jolla-camera.profile
@@ -7,8 +7,8 @@
 # x-sailjail-description = Execute jolla-camera application
 
 ### PERMISSIONS
-# x-sailjail-permission = Camera,Pictures,Vides,MediaIndexing,Location,UDisks,Privileged
+# x-sailjail-permission = Camera,Pictures,Videos,MediaIndexing,Location,UDisks,Privileged
 
 ### APPLICATION
-private-bin jolla-camera
+private-bin jolla-camera,jolla-camera-lockscreen
 dbus-user.own com.jolla.camera


### PR DESCRIPTION
This was preventing lockscreen camera from working inside jail.