### PR TITLE
[sailjail] Add long descriptions. Fixes JB#52256

### DIFF
--- a/permissions/Accounts.permission
+++ b/permissions/Accounts.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-accounts
-# x-sailjail-description = Access accounts
+# x-sailjail-translation-key-description = permission-la-accounts
+# x-sailjail-description = Accounts
+# x-sailjail-translation-key-long-description = permission-la-accounts_description
+# x-sailjail-long-description = Create, modify and delete accounts
 
 whitelist /usr/share/jolla-settings/pages/accounts
 whitelist /usr/share/xml/accounts

--- a/permissions/Ambience.permission
+++ b/permissions/Ambience.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-ambience
+# x-sailjail-translation-key-description = permission-la-ambience
 # x-sailjail-description = Ambience
+# x-sailjail-translation-key-long-description = permission-la-ambience_description
+# x-sailjail-long-description = Create, modify and delete ambiences
 
 mkdir     ${HOME}/.local/share/ambienced/wallpapers
 whitelist ${HOME}/.local/share/ambienced/wallpapers

--- a/permissions/AppLaunch.permission
+++ b/permissions/AppLaunch.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-app_launch
-# x-sailjail-description = Start user services
+# x-sailjail-translation-key-description = permission-la-app_launch
+# x-sailjail-description = User services
+# x-sailjail-translation-key-long-description = permission-la-app_launch_description
+# x-sailjail-long-description = Start and stop user services
 
 # BEG sessionbus-org.freedesktop.systemd1.resource
 dbus-user.talk org.freedesktop.systemd1

--- a/permissions/ApplicationInstallation.permission
+++ b/permissions/ApplicationInstallation.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-application_installation
+# x-sailjail-translation-key-description = permission-la-application_installation
 # x-sailjail-description = Install apps
+# x-sailjail-translation-key-long-description = permission-la-application_installation_description
+# x-sailjail-long-description = Install and uninstall applications
 
 whitelist /var/cache/PackageKit/downloads
 

--- a/permissions/Audio.permission
+++ b/permissions/Audio.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-audio
+# x-sailjail-translation-key-description = permission-la-audio
 # x-sailjail-description = Play audio
+# x-sailjail-translation-key-long-description = permission-la-audio_description
+# x-sailjail-long-description = Play audio and show audio controls on lockscreen
 
 private-etc pulse
 

--- a/permissions/Base.permission
+++ b/permissions/Base.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Base permissions
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 writable-run-user
 

--- a/permissions/Bluetooth.permission
+++ b/permissions/Bluetooth.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-bluetooth_and_nfc
-# x-sailjail-description = Access Bluetooth and NFC
+# x-sailjail-translation-key-description = permission-la-bluetooth_and_nfc
+# x-sailjail-description = Bluetooth and NFC
+# x-sailjail-translation-key-long-description = permission-la-bluetooth_and_nfc_description
+# x-sailjail-long-description = Connect and use Bluetooth and NFC devices
 
 # BEG sessionbus-org.bluez.obex.resource
 dbus-user.talk org.bluez.obex

--- a/permissions/Calendar.permission
+++ b/permissions/Calendar.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-calendar
-# x-sailjail-description = Access calendar
+# x-sailjail-translation-key-description = permission-la-calendar
+# x-sailjail-description = Calendar
+# x-sailjail-translation-key-long-description = permission-la-calendar_description
+# x-sailjail-long-description = Display and edit calendar events
 
 whitelist /usr/share/jolla-calendar
 

--- a/permissions/Camera.permission
+++ b/permissions/Camera.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-camera
-# x-sailjail-description = Take photos and videos
+# x-sailjail-translation-key-description = permission-la-camera
+# x-sailjail-description = Camera
+# x-sailjail-translation-key-long-description = permission-la-camera_description
+# x-sailjail-long-description = Take photos and videos
 # This is about access to device's camera hardware, not data
 
 # BEG systembus-org.maemo.resource.manager

--- a/permissions/Connman.permission
+++ b/permissions/Connman.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Change network setup
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 # BEG systembus-net.connman.resource
 dbus-system.talk net.connman

--- a/permissions/Contacts.permission
+++ b/permissions/Contacts.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-contacts
-# x-sailjail-description = Access contacts
+# x-sailjail-translation-key-description = permission-la-contacts
+# x-sailjail-description = Contacts
+# x-sailjail-translation-key-long-description = permission-la-contacts_description
+# x-sailjail-long-description = Display and edit contacts
 
 whitelist /usr/share/jolla-settings/pages/jolla-contacts
 whitelist /usr/share/jolla-contacts

--- a/permissions/DataStorages.permission
+++ b/permissions/DataStorages.permission
@@ -1,5 +1,7 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access removable media
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Removable media
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description = Use memory cards and USB sticks

--- a/permissions/Documents.permission
+++ b/permissions/Documents.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-documents
-# x-sailjail-description = Access documents
+# x-sailjail-translation-key-description = permission-la-documents
+# x-sailjail-description = Documents
+# x-sailjail-translation-key-long-description = permission-la-documents_description
+# x-sailjail-long-description = Use stored document files
 
 mkdir     ${HOME}/Documents
 whitelist ${HOME}/Documents

--- a/permissions/Downloads.permission
+++ b/permissions/Downloads.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-downloads
-# x-sailjail-description = Access downloads
+# x-sailjail-translation-key-description = permission-la-downloads
+# x-sailjail-description = Downloads
+# x-sailjail-translation-key-long-description = permission-la-downloads_description
+# x-sailjail-long-description = Use downloaded files
 
 mkdir     ${HOME}/Downloads
 whitelist ${HOME}/Downloads

--- a/permissions/Email.permission
+++ b/permissions/Email.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-email
-# x-sailjail-description = Access email
+# x-sailjail-translation-key-description = permission-la-email
+# x-sailjail-description = Email
+# x-sailjail-translation-key-long-description = permission-la-email_description
+# x-sailjail-long-description = Read and send email
 
 whitelist /usr/share/jolla-settings/pages/jolla-email
 whitelist /usr/share/jolla-email

--- a/permissions/FingerprintSensor.permission
+++ b/permissions/FingerprintSensor.permission
@@ -1,5 +1,7 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access fingerprint sensor
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Fingerprint sensor
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =

--- a/permissions/Internet.permission
+++ b/permissions/Internet.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-internet
-# x-sailjail-description = Access Internet
+# x-sailjail-translation-key-description = permission-la-internet
+# x-sailjail-description = Internet
+# x-sailjail-translation-key-long-description = permission-la-internet_description
+# x-sailjail-long-description = Use and control internet connectivity
 
 # XXX: does "netlink" really belong here?
 ### network

--- a/permissions/Location.permission
+++ b/permissions/Location.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-positioning
-# x-sailjail-description = Access positioning
+# x-sailjail-translation-key-description = permission-la-positioning
+# x-sailjail-description = Positioning
+# x-sailjail-translation-key-long-description = permission-la-positioning_description
+# x-sailjail-long-description = Use high and low accuracy positioning
 
 whitelist /usr/share/GConf/gsettings/geoclue
 

--- a/permissions/MediaIndexing.permission
+++ b/permissions/MediaIndexing.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-media_indexing
-# x-sailjail-description = Access media index
+# x-sailjail-translation-key-description = permission-la-media_indexing
+# x-sailjail-description = Media index
+# x-sailjail-translation-key-long-description = permission-la-media_indexing_description
+# x-sailjail-long-description = List files stored on device
 
 whitelist /usr/share/tracker
 

--- a/permissions/Messages.permission
+++ b/permissions/Messages.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-messages
-# x-sailjail-description = Access messages
+# x-sailjail-translation-key-description = permission-la-messages
+# x-sailjail-description = Messages
+# x-sailjail-translation-key-long-description = permission-la-messages_description
+# x-sailjail-long-description = Display and send SMS and other types of messages
 
 # BEG systembus-org.ofono.resource
 dbus-system.talk org.ofono

--- a/permissions/Microphone.permission
+++ b/permissions/Microphone.permission
@@ -1,5 +1,7 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access microphone
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Microphone
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =

--- a/permissions/Mozilla.permission
+++ b/permissions/Mozilla.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-webview
-# x-sailjail-description = Access webview
+# x-sailjail-translation-key-description = permission-la-webview
+# x-sailjail-description = Web content
+# x-sailjail-translation-key-long-description = permission-la-webview_description
+# x-sailjail-long-description = Viewing web content
 
 private-etc ssl,hosts,pki,crypto-policies
 

--- a/permissions/Music.permission
+++ b/permissions/Music.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-music
-# x-sailjail-description = Access music
+# x-sailjail-translation-key-description = permission-la-music
+# x-sailjail-description = Music
+# x-sailjail-translation-key-long-description = permission-la-music_description
+# x-sailjail-long-description = Use stored music files
 
 mkdir     ${HOME}/Music
 whitelist ${HOME}/Music

--- a/permissions/Notes.permission
+++ b/permissions/Notes.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access notes
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Notes
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 whitelist /usr/share/jolla-notes
 whitelist /usr/share/jolla-settings/pages/jolla-notes

--- a/permissions/Notifications.permission
+++ b/permissions/Notifications.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-notification
-# x-sailjail-description = Access notifications
+# x-sailjail-translation-key-description = permission-la-notification
+# x-sailjail-description = Notifications
+# x-sailjail-translation-key-long-description = permission-la-notification_description
+# x-sailjail-long-description = Display notifications
 
 whitelist /usr/share/lipstick-jolla-home-qt5/notifications
 

--- a/permissions/Phone.permission
+++ b/permissions/Phone.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-phone
-# x-sailjail-description = Access phone
+# x-sailjail-translation-key-description = permission-la-phone
+# x-sailjail-description = Phone
+# x-sailjail-translation-key-long-description = permission-la-phone_description
+# x-sailjail-long-description = Make phone calls
 
 # BEG systembus-org.ofono.resource
 dbus-system.talk org.ofono

--- a/permissions/Pictures.permission
+++ b/permissions/Pictures.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-pictures
-# x-sailjail-description = Access pictures
+# x-sailjail-translation-key-description = permission-la-pictures
+# x-sailjail-description = Pictures
+# x-sailjail-translation-key-long-description = permission-la-pictures_description
+# x-sailjail-long-description = Use stored picture files
 
 mkdir     ${HOME}/Pictures
 whitelist ${HOME}/Pictures

--- a/permissions/Privileged.permission
+++ b/permissions/Privileged.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access privileged user data
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Privileged user data
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 # We have library code that checks whether privileged
 # data directory uid=privileged and gid=privileged.

--- a/permissions/Sensors.permission
+++ b/permissions/Sensors.permission
@@ -1,5 +1,7 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
-# x-sailjail-description = Access sensors
+# x-sailjail-translation-key-description =
+# x-sailjail-description = Sensors
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =

--- a/permissions/Sharing.permission
+++ b/permissions/Sharing.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-sharing
-# x-sailjail-description = Access sharing methods
+# x-sailjail-translation-key-description = permission-la-sharing
+# x-sailjail-description = Sharing
+# x-sailjail-translation-key-long-description = permission-la-sharing_description
+# x-sailjail-long-description = Share data via bluetooth, email and other accounts
 
 # Transferengine
 whitelist /usr/share/nemo-transferengine

--- a/permissions/SyncFW.permission
+++ b/permissions/SyncFW.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-synchronization
-# x-sailjail-description = Use data synchronization
+# x-sailjail-translation-key-description = permission-la-synchronization
+# x-sailjail-description = Synchronization
+# x-sailjail-translation-key-long-description = permission-la-synchronization_description
+# x-sailjail-long-description = Synchronize data between device and online accounts
 
 private-etc buteo
 

--- a/permissions/Thumbnails.permission
+++ b/permissions/Thumbnails.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-thumbnails
-# x-sailjail-description = Access thumbnails
+# x-sailjail-translation-key-description = permission-la-thumbnails
+# x-sailjail-description = Thumbnails
+# x-sailjail-translation-key-long-description = permission-la-thumbnails_description
+# x-sailjail-long-description = Create and display thumbnail pictures
 
 # Thumbnailer service returns paths in thumbnail cache
 # -> service must be callable

--- a/permissions/UDisks.permission
+++ b/permissions/UDisks.permission
@@ -3,8 +3,10 @@
 # FIXME: what exactly requires udisks???
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Use UDisks2
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 # BEG systembus-org.freedesktop.UDisks2.resource
 dbus-system.talk org.freedesktop.UDisks2

--- a/permissions/Videos.permission
+++ b/permissions/Videos.permission
@@ -1,8 +1,10 @@
 # -*- mode: sh -*-
 
 # x-sailjail-translation-catalog = sailjail-permissions
-# x-sailjail-translation-key = permission-la-videos
-# x-sailjail-description = Access videos
+# x-sailjail-translation-key-description = permission-la-videos
+# x-sailjail-description = Videos
+# x-sailjail-translation-key-long-description = permission-la-videos_description
+# x-sailjail-long-description = Use stored video files
 
 mkdir     ${HOME}/Videos
 whitelist ${HOME}/Videos

--- a/permissions/jolla-calculator.profile
+++ b/permissions/jolla-calculator.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-calculator
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-calculator application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 

--- a/permissions/jolla-calendar.profile
+++ b/permissions/jolla-calendar.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-calendar
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-calendar application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Accounts

--- a/permissions/jolla-camera.profile
+++ b/permissions/jolla-camera.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-camera
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-camera application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Camera,Pictures,Videos,MediaIndexing,Location,Privileged

--- a/permissions/jolla-clock.profile
+++ b/permissions/jolla-clock.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-clock
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-clock application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 

--- a/permissions/jolla-contacts.profile
+++ b/permissions/jolla-contacts.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-contacts
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-contacts application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Bluetooth

--- a/permissions/jolla-email.profile
+++ b/permissions/jolla-email.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-email
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-email application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Accounts

--- a/permissions/jolla-gallery.profile
+++ b/permissions/jolla-gallery.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-gallery
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-gallery application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Pictures

--- a/permissions/jolla-mediaplayer.profile
+++ b/permissions/jolla-mediaplayer.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-mediaplayer
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-mediaplayer application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Music

--- a/permissions/jolla-messages.profile
+++ b/permissions/jolla-messages.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-messages
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-messages application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Contacts

--- a/permissions/jolla-notes.profile
+++ b/permissions/jolla-notes.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/jolla-notes
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute jolla-notes application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Notes

--- a/permissions/sailfish-browser.profile
+++ b/permissions/sailfish-browser.profile
@@ -3,8 +3,10 @@
 # Firejail profile for /usr/bin/sailfish-browser
 
 # x-sailjail-translation-catalog =
-# x-sailjail-translation-key =
+# x-sailjail-translation-key-description =
 # x-sailjail-description = Execute sailfish-browser application
+# x-sailjail-translation-key-long-description =
+# x-sailjail-long-description =
 
 ### PERMISSIONS
 # x-sailjail-permission = Accounts


### PR DESCRIPTION
Add long descriptions to permissions and adjust short descriptions.
Change x-sailjail-transation-key to x-sailjail-transation-key-description.