### PR TITLE
[sailjail] Remove -- argument if it exists. Fixes JB#53331

### DIFF
--- a/src/jail_plugins.c
+++ b/src/jail_plugins.c
@@ -58,7 +58,7 @@ jail_plugins_scan_plugin_dir(
     GDir* dir = g_dir_open(plugin_dir, 0, NULL);
 
     if (dir) {
-	const char* file;
+	    const char* file;
 
         while ((file = g_dir_read_name(dir)) != NULL) {
             if (!g_str_has_prefix(file, "lib") &&

--- a/src/sailjail.c
+++ b/src/sailjail.c
@@ -361,6 +361,12 @@ int main(int argc, char* argv[])
     ok = g_option_context_parse(options, &argc, &argv, &error);
 
     if (ok) {
+        /* Remove "--" from the list if it is there */
+        if (argc > 1 && !strcmp(argv[1], "--")) {
+            argv[1] = argv[0];
+            argv++;
+            argc--;
+        }
         if (argc > 1) {
             ret = sailjail_main(argc, argv, conf, &args);
         } else {


### PR DESCRIPTION
Glib's g_option_context_parse() may leave "--" argument in place if
there are other arguments starting with "-" after it. Remove it from
argv before continuing.