### PR TITLE
Require absolute paths for binaries and other checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Example desktop file
     ApplicationName=myapp
 
 With above example application desktop file Firejail command line arguments contain implicitly *--dbus-user.own=org.foobar.myapp* when launched through Sailjail.
+Use of absolute paths is required, except for the desktop file if it is located in /usr/share/applications which is also required by homescreen integration in most cases.
 
 ## Homescreen integration
 

--- a/src/jail_conf.c
+++ b/src/jail_conf.c
@@ -85,9 +85,14 @@ jail_conf_parse(
 
     str = g_key_file_get_string(f, SECTION, KEY_EXEC, NULL);
     if (str) {
-        g_free(priv->exec);
-        conf->exec = priv->exec = str;
-        GDEBUG("  %s=%s", KEY_EXEC, conf->exec);
+        if (str[0] != '/') {
+            /* Protecting user from bad decisions */
+            GWARN("[sailjail] " KEY_EXEC "value '%s' must be an absolute path, ignoring!", str);
+        } else {
+            g_free(priv->exec);
+            conf->exec = priv->exec = str;
+            GDEBUG("  %s=%s", KEY_EXEC, conf->exec);
+        }
     }
 
     str = g_key_file_get_string(f, SECTION, KEY_PLUGIN_DIR, NULL);

--- a/src/jail_free.c
+++ b/src/jail_free.c
@@ -69,7 +69,7 @@ jail_free(
             (guint)creds->euid, (guint)creds->suid, strerror(errno)));
     } else {
         fflush(NULL);
-        execvp(argv[0], (char**) argv);
+        execv(argv[0], (char**) argv);
         g_propagate_error(error, g_error_new(G_UNIX_ERROR, errno,
             "exec(%s) error: %s", argv[0], strerror(errno)));
     }

--- a/src/jail_rules.c
+++ b/src/jail_rules.c
@@ -64,7 +64,7 @@ static const char SAILJAIL_SECTION_DESKTOP_DEFAULT[] =
 static const char SAILJAIL_SECTION_DEFAULT[] = DEFAULT_PROFILE_SECTION;
 static const char SAILJAIL_LIST_SEPARATORS[] = ":;,";
 
-static const char SAILJAIL_KEY_PERMS[] = "Permissions";
+static const char SAILJAIL_KEY_PERMS[] = PERMISSION_LIST_KEY;
 #define SAILJAIL_KEY_PERM_REQUIRED '!'
 #define SAILJAIL_KEY_PERM_OPTIONAL '?'
 

--- a/src/jail_rules_p.h
+++ b/src/jail_rules_p.h
@@ -42,6 +42,7 @@
 
 #define DEFAULT_PROFILE_SECTION "Sailjail"
 #define ALTERNATE_DEFAULT_PROFILE_SECTION "X-" DEFAULT_PROFILE_SECTION
+#define PERMISSION_LIST_KEY "Permissions"
 
 typedef struct jail_rules_opt {
     const char* profile;

--- a/src/jail_run.c
+++ b/src/jail_run.c
@@ -331,7 +331,7 @@ jail_run(
             (guint)creds->euid, (guint)creds->suid, strerror(errno)));
     } else {
         fflush(NULL);
-        execvp(conf->exec, (char**) args->pdata);
+        execv(conf->exec, (char**) args->pdata);
         g_propagate_error(error, g_error_new(G_UNIX_ERROR, errno,
             "exec(%s) error: %s", conf->exec, strerror(errno)));
     }

--- a/src/sailjail.c
+++ b/src/sailjail.c
@@ -369,7 +369,12 @@ int main(int argc, char* argv[])
             argc--;
         }
         if (argc > 1) {
-            ret = sailjail_main(argc, argv, conf, &args);
+            /* PROGRAM must be defined with an absolute path */
+            if (argv[1][0] != '/') {
+                fprintf(stderr, "%s: must be an absolute path\n", argv[1]);
+            } else {
+                ret = sailjail_main(argc, argv, conf, &args);
+            }
         } else {
             char* help = g_option_context_get_help(options, TRUE, NULL);
 

--- a/src/sailjail.c
+++ b/src/sailjail.c
@@ -166,6 +166,12 @@ jail_opt_context_new(
 
     g_option_context_set_strict_posix(options, TRUE);
     g_option_context_set_summary(options, "Runs PROGRAM in a sandbox.");
+    g_option_context_set_description(options,
+        "PROGRAM must be an absolute path to application binary "
+        "to run in a sandbox.\n\n"
+        "Application profile is usually a desktop entry file defining ["
+        ALTERNATE_DEFAULT_PROFILE_SECTION "] section and "
+        PERMISSION_LIST_KEY " key.");
     return options;
 }
 


### PR DESCRIPTION
This makes sailjail to require absolute paths for the application binary and also for firejail binary if it's overridden in configuration. Similarly this changes execvp() calls to execv() and adds a note about absolute paths to help output. Last it adds checks that the executable is what sailjail/firejail expects for developer convenience.