### PR TITLE
Implement sailjail permission daemon

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ PKGS = $(LIB_PKGS)
 # Default target
 #
 
-all: debug release pkgconfig
+all:: debug release pkgconfig
 
 #
 # Sources
@@ -171,7 +171,7 @@ print_release_test_lib:
 print_coverage_test_lib:
 	@echo $(COVERAGE_TEST_LIB)
 
-clean:
+clean::
 	rm -fr $(BUILD_DIR)
 	make -C unit clean
 
@@ -233,7 +233,7 @@ INSTALL_BIN_DIR = $(DESTDIR)/usr/bin
 INSTALL_INCLUDE_DIR = $(DESTDIR)/usr/include/sailjail
 INSTALL_PKGCONFIG_DIR = $(DESTDIR)$(ABS_LIBDIR)/pkgconfig
 
-install: $(INSTALL_BIN_DIR)
+install:: $(INSTALL_BIN_DIR)
 	$(INSTALL_BIN) $(RELEASE_EXE) $(INSTALL_BIN_DIR)
 
 install-dev: $(INSTALL_INCLUDE_DIR) $(INSTALL_PKGCONFIG_DIR)

--- a/daemon/.depend
+++ b/daemon/.depend
@@ -1,0 +1,260 @@
+appinfo.o:\
+	appinfo.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	stringset.h\
+	util.h\
+
+appinfo.pic.o:\
+	appinfo.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	stringset.h\
+	util.h\
+
+applications.o:\
+	applications.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	stringset.h\
+	util.h\
+
+applications.pic.o:\
+	applications.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	stringset.h\
+	util.h\
+
+config.o:\
+	config.c\
+	config.h\
+	logging.h\
+	util.h\
+
+config.pic.o:\
+	config.c\
+	config.h\
+	logging.h\
+	util.h\
+
+control.o:\
+	control.c\
+	applications.h\
+	control.h\
+	later.h\
+	logging.h\
+	permissions.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+	users.h\
+
+control.pic.o:\
+	control.c\
+	applications.h\
+	control.h\
+	later.h\
+	logging.h\
+	permissions.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+	users.h\
+
+desktop_data.o:\
+	desktop_data.c\
+	util.h\
+
+desktop_data.pic.o:\
+	desktop_data.c\
+	util.h\
+
+later.o:\
+	later.c\
+	later.h\
+	logging.h\
+
+later.pic.o:\
+	later.c\
+	later.h\
+	logging.h\
+
+logging.o:\
+	logging.c\
+	logging.h\
+	util.h\
+
+logging.pic.o:\
+	logging.c\
+	logging.h\
+	util.h\
+
+mainloop.o:\
+	mainloop.c\
+	mainloop.h\
+
+mainloop.pic.o:\
+	mainloop.c\
+	mainloop.h\
+
+permissions.o:\
+	permissions.c\
+	control.h\
+	logging.h\
+	permissions.h\
+	stringset.h\
+	util.h\
+
+permissions.pic.o:\
+	permissions.c\
+	control.h\
+	logging.h\
+	permissions.h\
+	stringset.h\
+	util.h\
+
+prompter.o:\
+	prompter.c\
+	appinfo.h\
+	control.h\
+	logging.h\
+	prompter.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+	util.h\
+
+prompter.pic.o:\
+	prompter.c\
+	appinfo.h\
+	control.h\
+	logging.h\
+	prompter.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+	util.h\
+
+sailjaild.o:\
+	sailjaild.c\
+	config.h\
+	control.h\
+	logging.h\
+	mainloop.h\
+	util.h\
+
+sailjaild.pic.o:\
+	sailjaild.c\
+	config.h\
+	control.h\
+	logging.h\
+	mainloop.h\
+	util.h\
+
+service.o:\
+	service.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	mainloop.h\
+	permissions.h\
+	prompter.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+
+service.pic.o:\
+	service.c\
+	appinfo.h\
+	applications.h\
+	control.h\
+	logging.h\
+	mainloop.h\
+	permissions.h\
+	prompter.h\
+	service.h\
+	session.h\
+	settings.h\
+	stringset.h\
+
+session.o:\
+	session.c\
+	control.h\
+	logging.h\
+	session.h\
+	util.h\
+
+session.pic.o:\
+	session.c\
+	control.h\
+	logging.h\
+	session.h\
+	util.h\
+
+settings.o:\
+	settings.c\
+	appinfo.h\
+	control.h\
+	logging.h\
+	settings.h\
+	stringset.h\
+	util.h\
+
+settings.pic.o:\
+	settings.c\
+	appinfo.h\
+	control.h\
+	logging.h\
+	settings.h\
+	stringset.h\
+	util.h\
+
+stringset.o:\
+	stringset.c\
+	stringset.h\
+
+stringset.pic.o:\
+	stringset.c\
+	stringset.h\
+
+users.o:\
+	users.c\
+	control.h\
+	logging.h\
+	users.h\
+	util.h\
+
+users.pic.o:\
+	users.c\
+	control.h\
+	logging.h\
+	users.h\
+	util.h\
+
+util.o:\
+	util.c\
+	logging.h\
+	stringset.h\
+	util.h\
+
+util.pic.o:\
+	util.c\
+	logging.h\
+	stringset.h\
+	util.h\
+

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -1,0 +1,276 @@
+# ----------------------------------------------------------- -*- mode: sh -*-
+# Package version
+# ----------------------------------------------------------------------------
+
+VERSION   ?= $(shell awk '/^Version:/ {print $$2}' ../rpm/sailjail.spec)
+
+# ----------------------------------------------------------------------------
+# Installation directories
+# ----------------------------------------------------------------------------
+
+# Dummy default install dir - override from packaging scripts
+DESTDIR         ?= /tmp/sailjaild-test-install
+
+# Standard install directories
+_PREFIX         ?= /usr#                         # /usr
+_INCLUDEDIR     ?= $(_PREFIX)/include#           # /usr/include
+_EXEC_PREFIX    ?= $(_PREFIX)#                   # /usr
+_BINDIR         ?= $(_EXEC_PREFIX)/bin#          # /usr/bin
+_SBINDIR        ?= $(_EXEC_PREFIX)/sbin#         # /usr/sbin
+_LIBEXECDIR     ?= $(_EXEC_PREFIX)/libexec#      # /usr/libexec
+_LIBDIR         ?= $(_EXEC_PREFIX)/lib#          # /usr/lib
+_SYSCONFDIR     ?= /etc#                         # /etc
+_DATADIR        ?= $(_PREFIX)/share#             # /usr/share
+_MANDIR         ?= $(_DATADIR)/man#              # /usr/share/man
+_INFODIR        ?= $(_DATADIR)/info#             # /usr/share/info
+_DEFAULTDOCDIR  ?= $(_DATADIR)/doc#              # /usr/share/doc
+_LOCALSTATEDIR  ?= /var#                         # /var
+_SHAREDSTATEDIR ?= $(_LOCALSTATEDIR)/lib#        # /var/lib
+_UNITDIR        ?= /lib/systemd/system#
+_USERUNITDIR    ?= /lib/systemd/user#
+_TESTSDIR       ?= /opt/tests#                   # /opt/tests
+
+# ----------------------------------------------------------------------------
+# List of targets to build
+# ----------------------------------------------------------------------------
+
+TARGETS_BIN += sailjaild
+
+## QUARANTINE TARGETS_PNG += sailjaild.png
+
+TARGETS += ${TARGETS_BIN} ${TARGETS_PNG}
+
+# ----------------------------------------------------------------------------
+# Top level targets
+# ----------------------------------------------------------------------------
+
+.PHONY: build install clean distclean mostlyclean
+
+build:: $(TARGETS)
+
+install:: build
+	install -d ${DESTDIR}${_BINDIR}
+	install -m755 ${TARGETS_BIN} ${DESTDIR}${_BINDIR}
+
+clean:: mostlyclean
+	$(RM) $(TARGETS)
+
+distclean:: clean
+	$(RM) tags
+
+mostlyclean::
+	$(RM) *.o *~ *.bak */*.o */*~ */*.bak
+
+# ----------------------------------------------------------------------------
+# Default flags
+# ----------------------------------------------------------------------------
+
+CPPFLAGS += -DVERSION='"${VERSION}"'
+CPPFLAGS += -DSYSCONFDIR='"${_SYSCONFDIR}"'
+CPPFLAGS += -DSHAREDSTATEDIR='"${_SHAREDSTATEDIR}"'
+CPPFLAGS += -DDATADIR='"${_DATADIR}"'
+
+CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -D_FILE_OFFSET_BITS=64
+
+COMMON   += -Wall
+COMMON   += -Os
+#COMMON   += -O0
+COMMON   += -g
+
+CFLAGS   += $(COMMON)
+CFLAGS   += -std=c99
+
+CXXFLAGS += $(COMMON)
+
+LDFLAGS  += -g
+
+LDLIBS   += -Wl,--as-needed
+
+# ----------------------------------------------------------------------------
+# Flags from pkg-config
+# ----------------------------------------------------------------------------
+
+PKG_NAMES += glib-2.0
+PKG_NAMES += gobject-2.0
+PKG_NAMES += gio-2.0
+PKG_NAMES += libsystemd
+
+maintenance  = normalize clean distclean mostlyclean
+intersection = $(strip $(foreach w,$1, $(filter $w,$2)))
+ifneq ($(call intersection,$(maintenance),$(MAKECMDGOALS)),)
+PKG_CONFIG   ?= true
+endif
+
+ifneq ($(strip $(PKG_NAMES)),)
+PKG_CONFIG   ?= pkg-config
+PKG_CFLAGS   := $(shell $(PKG_CONFIG) --cflags $(PKG_NAMES))
+PKG_LDLIBS   := $(shell $(PKG_CONFIG) --libs   $(PKG_NAMES))
+PKG_CPPFLAGS := $(filter -D%,$(PKG_CFLAGS)) $(filter -I%,$(PKG_CFLAGS))
+PKG_CFLAGS   := $(filter-out -I%, $(filter-out -D%, $(PKG_CFLAGS)))
+endif
+
+CPPFLAGS += $(PKG_CPPFLAGS)
+CFLAGS   += $(PKG_CFLAGS)
+LDLIBS   += $(PKG_LDLIBS)
+
+# ----------------------------------------------------------------------------
+# Implicit rules
+# ----------------------------------------------------------------------------
+
+%.so : %.o
+	$(CC) -o $@ -shared $^ $(LDFLAGS) $(LDLIBS)
+
+%.png : %.dot
+	dot -Tpng $^ -o $@
+
+# ----------------------------------------------------------------------------
+# Explicit dependencies
+# ----------------------------------------------------------------------------
+
+# - - - - - - - - - - - - - - - - - - - -
+# sailjaild
+# - - - - - - - - - - - - - - - - - - - -
+
+sailjaild_objs += sailjaild.o
+
+sailjaild_objs += appinfo.o
+sailjaild_objs += applications.o
+sailjaild_objs += config.o
+sailjaild_objs += control.o
+sailjaild_objs += later.o
+sailjaild_objs += logging.o
+sailjaild_objs += mainloop.o
+sailjaild_objs += permissions.o
+sailjaild_objs += prompter.o
+sailjaild_objs += service.o
+sailjaild_objs += session.o
+sailjaild_objs += settings.o
+sailjaild_objs += stringset.o
+sailjaild_objs += users.o
+sailjaild_objs += util.o
+
+sailjaild : ${sailjaild_objs}
+
+# - - - - - - - - - - - - - - - - - - - -
+# desktop_data
+# - - - - - - - - - - - - - - - - - - - -
+
+desktop_data : desktop_data.o util.o logging.o stringset.o
+
+clean::
+	$(RM) desktop_data
+
+# ----------------------------------------------------------------------------
+# Source code normalization
+# ----------------------------------------------------------------------------
+
+.PHONY: normalize
+normalize::
+	normalize_whitespace -M Makefile
+	normalize_whitespace -a $(wildcard *.[ch] *.cc *.cpp)
+	normalize_whitespace -a README $(wildcard *.dot)
+
+# ----------------------------------------------------------------------------
+# AUTOMATIC PROTOTYPE GENERFATION
+# ----------------------------------------------------------------------------
+
+.SUFFIXES: .q .p .g
+.PRECIOUS: .q
+
+ALL_SOURCES += appinfo.c
+ALL_SOURCES += applications.c
+ALL_SOURCES += config.c
+ALL_SOURCES += control.c
+ALL_SOURCES += desktop_data.c
+ALL_SOURCES += later.c
+ALL_SOURCES += logging.c
+ALL_SOURCES += mainloop.c
+ALL_SOURCES += permissions.c
+ALL_SOURCES += prompter.c
+ALL_SOURCES += sailjaild.c
+ALL_SOURCES += service.c
+ALL_SOURCES += session.c
+ALL_SOURCES += settings.c
+ALL_SOURCES += stringset.c
+ALL_SOURCES += users.c
+ALL_SOURCES += util.c
+
+ALL_HEADERS += appinfo.h
+ALL_HEADERS += applications.h
+ALL_HEADERS += config.h
+ALL_HEADERS += control.h
+ALL_HEADERS += later.h
+ALL_HEADERS += logging.h
+ALL_HEADERS += mainloop.h
+ALL_HEADERS += permissions.h
+ALL_HEADERS += prompter.h
+ALL_HEADERS += service.h
+ALL_HEADERS += session.h
+ALL_HEADERS += settings.h
+ALL_HEADERS += stringset.h
+ALL_HEADERS += users.h
+ALL_HEADERS += util.h
+
+PROTO_CPPFLAGS += -D_Float32=float
+PROTO_CPPFLAGS += -D_Float64=double
+PROTO_CPPFLAGS += -D_Float128="long double"
+PROTO_CPPFLAGS += -D_Float32x=float
+PROTO_CPPFLAGS += -D_Float64x=double
+PROTO_CPPFLAGS += -D_Float128x="long double"
+
+%.q : CPPFLAGS += $(PROTO_CPPFLAGS)
+%.q : %.c ; $(CC) -o $@ -E $< $(CPPFLAGS) -O
+%.p : %.q prettyproto.groups ; cproto -s < $< | prettyproto.py > $@
+%.g : %.q prettyproto.groups ; cproto    < $< | prettyproto.py > $@
+
+distclean::
+	$(RM) *.[qpg]
+
+protos-pre: $(patsubst %.c,%.q,$(ALL_SOURCES))
+	touch $@
+
+protos-post: $(patsubst %.c,%.p,$(ALL_SOURCES)) $(patsubst %.c,%.g,$(ALL_SOURCES))
+	touch $@
+
+clean::
+	$(RM) protos-pre protos-post
+
+# ----------------------------------------------------------------------------
+# AUTOMATIC HEADER DEPENDENCIES
+# ----------------------------------------------------------------------------
+
+.PHONY: depend
+depend::
+	@echo "Updating .depend"
+	$(CC) -MM $(CPPFLAGS) $(ALL_SOURCES) |\
+	./depend_filter.py > .depend
+
+ifneq ($(MAKECMDGOALS),depend) # not while: make depend
+ifneq (,$(wildcard .depend))   # not if .depend does not exist
+include .depend
+endif
+endif
+
+fixme:
+	grep -nE '(FIXME|TODO|XXX)' -- *.[ch]
+
+# ----------------------------------------------------------------------------
+# REDUNDANT HEADERS
+# ----------------------------------------------------------------------------
+
+.SUFFIXES: %.trim
+.PRECIOUS: %.trim
+
+include_trim:: include_trim_headers include_trim_sources
+
+%.trim : %
+	find_unneeded_includes.py $(CPPFLAGS) $(CFLAGS) -- $<
+	touch $@
+
+include_trim_headers: $(patsubst %,%.trim,$(ALL_HEADERS))
+
+include_trim_sources: $(patsubst %,%.trim,$(ALL_SOURCES))
+
+distclean::
+	$(RM) *.trim

--- a/daemon/README
+++ b/daemon/README
@@ -1,0 +1,193 @@
+Existing User Tracking
+======================
+
+- tracking is done by:
+  - monitoring /etc/passwd file
+
+- maintained data:
+  - minimum UID
+  - maximum UID
+  - set of valid UID values
+
+- UID added:
+  - no action needed
+
+- UID removed:
+  - user must be dropped from settings data [NOT DONE]
+
+User Session Tracking
+=====================
+
+- tracks UID of current user
+
+- UID is used for:
+  - permissions checking/prompting
+
+- UID changed:
+  - cancels pending/queued prompts [NOT DONE]
+
+Permission File Tracking
+========================
+
+- tracking is done by:
+  - monitoring /etc/sailjail/permissions directory
+
+- maintained data:
+  - set of PERMISSION names
+
+- PERMISSION added/removed:
+  - triggers application data re-evaluation
+
+Desktop File Tracking
+=====================
+
+- tracking is done by:
+  - monitoring /usr/share/applications directory
+
+- maintained data:
+  - set of APPLICATION data, each with:
+    - Desktop properties: Name, Type, Exec, Icon
+    - Sailjail properties: Permissions
+
+- APPLICATION added:
+  - broadcast ApplicationAdded signal
+  - no other actions
+
+- APPLICATION removed:
+  - broadcast ApplicationAdded signal
+  - application settings for each user must be purged [NOT DONE]
+
+- APPLICATION changed:
+  - broadcast ApplicationAdded signal
+  - triggers settings data re-evaluation
+
+- dbus ipc:
+  - method QStringList GetApplications()
+    -> list of available application names
+
+  - method QVariantMap GetAppInfo(QString application)
+    -> application names to Name/Type/.. mapping
+
+  - signal void ApplicationAdded(QString application)
+  - signal void ApplicationRemoved(QString application)
+  - signal void ApplicationChanged(QString application)
+    - note that changed signal can occur also due to
+      - changes in permission data
+      - changes in user settings data
+
+User / Application Settings
+===========================
+
+- maintained data:
+  - tree of: settings(1) -> users(n) -> applications (n)
+  - leaf node holds:
+    - launch_allowed = UNSET|ALWAYS|NEVER
+    - granted_permissions:
+      - subset of: intersection of PERMISSIONS and APPLICATION.permissions
+      - cleared/filled on launch_allowed changes
+      - possible to modify while launch_allowed=ALWAYS
+    - license_agreed = UNSET|YES|NO
+      - proof of concept / placeholder (=how to add new data)
+
+- persistent storage:
+  - one file / user -> "applications for user"
+  - when loading / saving:
+    - data for invalid users / applications is ignored
+
+- dbus ipc:
+  - access to application / settings data
+    - UID / APPLICATION parameters are validated
+      - even if stale data is still held internally it is not exposed
+        over dbus interface
+
+  - method int GetLaunchAllowed(uint uid, QString application)
+  - method void SetLaunchAllowed(uint uid, QString application, int allowed)
+    - values: UNSET=0|ALWAYS=1|NEVER=2
+    - setter needs to be under access contrl [NOT DONE]
+    - changing value affects also granted permissions
+
+  - method QStringList GetGrantedPermissions(uint uid, QString application)
+  - method void SetGrantedPermissions(uint uid, QString application, QStringList permissions)
+    -> set of permissions granted to UID/APPLICATION
+
+  - method QStringList QueryLaunchPermissions(QString application)
+    - if application launch is allowed for current UID, returns permissions
+
+  - method QStringList PromptLaunchPermissions(QString application)
+    - if application launch is not allowed for current UID,
+      - prompt user and set allowed/granted according to responce
+    - if application launch is allowed for current UID, returns permissions
+
+  - method int GetLicenseAgreed(uint uid, QString application)
+  - method void SetLicenseAgreed(uint uid, QString application, int agreed)
+    - values: UNSET=0|YES=1|NO=2
+    - used only for: "how to add more data" demonstration
+
+  - method void Quit()
+    - terminates daemon
+    - debug feature, to be removed
+
+Internal Structure
+==================
+
+- names below map directly to source files
+- also used in architecture graph
+  - ref: dot -Tpng sailjaild.dot -o sailjaild.png
+
+- CONTROL: "root object"
+  - CONFIG: access to configuration data [not used atm]
+  - USERS: existing users tracking
+  - SESSION: user session tracking
+  - PERMISSIONS: *.permission file tracking, Exec/Permissions/etc properties
+  - SETTINGS: top level settings api/logic
+    - USER SETTINGS: persistent storage in user-UID.settings files
+      - APPLICATION SETTINGS: allowed/granted properties
+  - SERVICE: dbus service, incoming method calls, outgoing signals
+    - PROMPTER: session bus connection, queue/execute window prompt ipc
+
+Directories Used
+================
+
+- CONFIG:       "/etc/sailjail/config"
+- PERMISSIONS:  "/etc/sailjail/permissions"
+- APPLICATIONS: "/usr/share/applications"
+- SETTINGS:     "/usr/lib/sailjail/settings" [TBD, PLACEHOLDER]
+
+What Is Missing
+===============
+
+- basically we have a functioning thing, but ...
+
+- user prompting
+  - does asynchronous call to window prompt service
+    - but does not handle cancellation yet
+  - placeholder error replies
+    -> needs to be improved
+
+- dbus ipc
+ - access controls are missing
+    -> where and how needs to be defined and implemented
+ - still using placeholder names
+    -> needs to be decided
+
+- applications without APP.desktop
+  - originally sailjail allowed alternate file to be defined in command line
+  - this is not feasible with daemon setup
+  - proposal: use /etc/sailjail/applications/*.desktop files
+    - used in addition to /usr/share/applications/*.desktop files
+    - data from both is merged before use
+    - we can:
+      - provide desktop like data for ui-less applications
+      - override/augment data that is defined in application desktop
+
+- bypass confirmation configuration
+  - this is part of launch itself (=sailjail)
+  - does not concern daemon (=sailjaild)
+  - except for:
+    - if the permission set is "empty" when permission has not been granted
+    - how launcher obtains permissions that would be applicable if accepted?
+
+- data migration
+  - sandboxing feature has been in general use
+  - there is existing sailjail allowance data present in devices
+  - should be migrated to daemon and then purged

--- a/daemon/appinfo.c
+++ b/daemon/appinfo.c
@@ -1,0 +1,745 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "appinfo.h"
+
+#include "applications.h"
+#include "control.h"
+#include "stringset.h"
+#include "logging.h"
+#include "util.h"
+
+#include <sys/stat.h>
+
+#include <unistd.h>
+#include <errno.h>
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef enum
+{
+    APPINFO_STATE_UNSET,
+    APPINFO_STATE_VALID,
+    APPINFO_STATE_INVALID,
+    APPINFO_STATE_DELETED,
+} appinfo_state_t;
+
+static const char * const appinfo_state_name[] =
+{
+    [APPINFO_STATE_UNSET]   = "UNSET",
+    [APPINFO_STATE_VALID]   = "VALID",
+    [APPINFO_STATE_INVALID] = "INVALID",
+    [APPINFO_STATE_DELETED] = "DELETED",
+};
+
+typedef struct
+{
+    const char *key;
+    void (*set)(appinfo_t *, const char *);
+} appinfo_parser_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO
+ * ------------------------------------------------------------------------- */
+
+static void  appinfo_ctor      (appinfo_t *self, applications_t *applications, const gchar *id);
+static void  appinfo_dtor      (appinfo_t *self);
+appinfo_t   *appinfo_create    (applications_t *applications, const gchar *id);
+void         appinfo_delete    (appinfo_t *self);
+void         appinfo_delete_cb (void *self);
+gboolean     appinfo_equal     (const appinfo_t *self, const appinfo_t *that);
+gboolean     appinfo_equal_cb  (gconstpointer a, gconstpointer b);
+guint        appinfo_hash      (const appinfo_t *self);
+guint        appinfo_hash_cb   (gconstpointer key);
+GVariant    *appinfo_to_variant(const appinfo_t *self);
+gchar       *appinfo_to_string (const appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_ATTRIBUTE
+ * ------------------------------------------------------------------------- */
+
+bool            appinfo_valid       (const appinfo_t *self);
+control_t      *appinfo_control     (const appinfo_t *self);
+applications_t *appinfo_applications(const appinfo_t *self);
+const gchar    *appinfo_id          (const appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PROPERTY
+ * ------------------------------------------------------------------------- */
+
+static void             appinfo_set_dirty            (appinfo_t *self);
+static bool             appinfo_clear_dirty          (appinfo_t *self);
+static appinfo_state_t  appinfo_get_state            (const appinfo_t *self);
+static void             appinfo_set_state            (appinfo_t *self, appinfo_state_t state);
+const gchar            *appinfo_get_name             (const appinfo_t *self);
+const gchar            *appinfo_get_type             (const appinfo_t *self);
+const gchar            *appinfo_get_icon             (const appinfo_t *self);
+const gchar            *appinfo_get_exec             (const appinfo_t *self);
+bool                    appinfo_get_no_display       (const appinfo_t *self);
+const gchar            *appinfo_get_service          (const appinfo_t *self);
+const gchar            *appinfo_get_object           (const appinfo_t *self);
+const gchar            *appinfo_get_method           (const appinfo_t *self);
+const gchar            *appinfo_get_organization_name(const appinfo_t *self);
+const gchar            *appinfo_get_application_name (const appinfo_t *self);
+void                    appinfo_set_name             (appinfo_t *self, const gchar *name);
+void                    appinfo_set_type             (appinfo_t *self, const gchar *type);
+void                    appinfo_set_icon             (appinfo_t *self, const gchar *icon);
+void                    appinfo_set_exec             (appinfo_t *self, const gchar *exec);
+void                    appinfo_set_no_display       (appinfo_t *self, bool no_display);
+void                    appinfo_set_service          (appinfo_t *self, const gchar *service);
+void                    appinfo_set_object           (appinfo_t *self, const gchar *object);
+void                    appinfo_set_method           (appinfo_t *self, const gchar *method);
+void                    appinfo_set_organization_name(appinfo_t *self, const gchar *organization_name);
+void                    appinfo_set_application_name (appinfo_t *self, const gchar *application_name);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+bool         appinfo_has_permission      (const appinfo_t *self, const gchar *perm);
+stringset_t *appinfo_get_permissions     (const appinfo_t *self);
+bool         appinfo_evaluate_permissions(appinfo_t *self);
+void         appinfo_set_permissions     (appinfo_t *self, const stringset_t *in);
+void         appinfo_clear_permissions   (appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PARSE
+ * ------------------------------------------------------------------------- */
+
+bool appinfo_parse_desktop(appinfo_t *self);
+
+/* ========================================================================= *
+ * APPINFO
+ * ========================================================================= */
+
+/* Ref: data merged from all desktop files under /usr/share/applications
+ *
+ * [Desktop Entry]
+ * Type=Application
+ * Name=Settings
+ * Exec=/usr/bin/sailjail -p voicecall-ui.desktop /usr/bin/voicecall-ui
+ * NoDisplay=true
+ * Icon=icon-launcher-settings
+ * Comment=Sailfish MimeType Handler for Webcal URL
+ * X-Desktop-File-Install-Version=0.26
+ * X-MeeGo-Logical-Id=settings-ap-name
+ * X-MeeGo-Translation-Catalog=settings
+ * X-Maemo-Service=com.jolla.settings
+ * X-Maemo-Object-Path=/com/jolla/settings/ui
+ * X-Maemo-Method=com.jolla.settings.ui.importWebcal
+ * MimeType=x-scheme-handler/webcal;x-scheme-handler/webcals;
+ * Version=1.0
+ * X-Maemo-Fixed-Args=application/x-vpnc
+ *
+ * [X-Sailjail]
+ * Permissions=Phone;CallRecordings;Contacts;Bluetooth;Privileged;Sharing
+ * OrganizationName=com.jolla
+ * ApplicationName=voicecall
+ */
+
+struct appinfo_t
+{
+    // uplink
+    applications_t  *anf_applications;
+
+    gchar           *anf_appname;
+    appinfo_state_t  anf_state;
+    time_t           anf_dt_ctime;
+    bool             anf_dirty;
+
+    // desktop properties
+    gchar           *anf_dt_name;       // DESKTOP_KEY_NAME
+    gchar           *anf_dt_type;       // DESKTOP_KEY_TYPE
+    gchar           *anf_dt_icon;       // DESKTOP_KEY_ICON
+    gchar           *anf_dt_exec;       // DESKTOP_KEY_EXEC
+    bool             anf_dt_no_display; // DESKTOP_KEY_NO_DISPLAY
+
+    // maemo properties
+    gchar           *anf_mo_service;    // MAEMO_KEY_SERVICE
+    gchar           *anf_mo_object;     // MAEMO_KEY_OBJECT
+    gchar           *anf_mo_method;     // MAEMO_KEY_METHOD
+
+    // sailjail properties
+    gchar           *anf_sj_organization_name; // SAILJAIL_KEY_ORGANIZATION_NAME
+    gchar           *anf_sj_application_name;  // SAILJAIL_KEY_APPLICATION_NAME
+    stringset_t     *anf_sj_permissions_in;    // SAILJAIL_KEY_PERMISSIONS
+    stringset_t     *anf_sj_permissions_out;
+};
+
+/* Internally used placeholder for NULL string values.
+ * Note that this is not exposed over D-Bus.
+ */
+static const char appinfo_unknown[] = "(undefined)";
+
+static void
+appinfo_ctor(appinfo_t *self, applications_t *applications, const gchar *id)
+{
+    self->anf_applications         = applications;
+    self->anf_appname              = g_strdup(id);
+
+    self->anf_state                = APPINFO_STATE_UNSET;
+    self->anf_dt_ctime             = -1;
+    self->anf_dirty                = false;
+
+    self->anf_dt_name              = NULL;
+    self->anf_dt_type              = NULL;
+    self->anf_dt_icon              = NULL;
+    self->anf_dt_exec              = NULL;
+    self->anf_dt_no_display        = false;
+
+    self->anf_mo_service           = NULL;
+    self->anf_mo_object            = NULL;
+    self->anf_mo_method            = NULL;
+
+    self->anf_sj_permissions_in    = stringset_create();
+    self->anf_sj_permissions_out   = stringset_create();
+    self->anf_sj_organization_name = NULL;
+    self->anf_sj_application_name  = NULL;
+
+    log_info("appinfo(%s): create", appinfo_id(self));
+}
+
+static void
+appinfo_dtor(appinfo_t *self)
+{
+    log_info("appinfo(%s): delete", appinfo_id(self));
+
+    appinfo_set_name(self, NULL);
+    appinfo_set_type(self, NULL);
+    appinfo_set_icon(self, NULL);
+    appinfo_set_exec(self, NULL);
+
+    appinfo_set_service(self, NULL);
+    appinfo_set_object(self, NULL);
+    appinfo_set_method(self, NULL);
+
+    appinfo_set_organization_name(self, NULL);
+    appinfo_set_application_name(self, NULL);
+    stringset_delete_at(&self->anf_sj_permissions_in);
+    stringset_delete_at(&self->anf_sj_permissions_out);
+
+    change_string(&self->anf_appname, NULL);
+    self->anf_applications = NULL;
+}
+
+appinfo_t *
+appinfo_create(applications_t *applications, const gchar *id)
+{
+    appinfo_t *self = g_malloc0(sizeof *self);
+    appinfo_ctor(self, applications, id);
+    return self;
+}
+
+void
+appinfo_delete(appinfo_t *self)
+{
+    if( self ) {
+        appinfo_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+appinfo_delete_cb(void *self)
+{
+    appinfo_delete(self);
+}
+
+gboolean
+appinfo_equal(const appinfo_t *self, const appinfo_t *that)
+{
+    return g_str_equal(appinfo_id(self), appinfo_id(that));
+}
+
+gboolean
+appinfo_equal_cb(gconstpointer a, gconstpointer b)
+{
+    return appinfo_equal(a, b);
+}
+
+guint
+appinfo_hash(const appinfo_t *self)
+{
+    return g_str_hash(appinfo_id(self));
+}
+
+guint
+appinfo_hash_cb(gconstpointer key)
+{
+    return appinfo_hash(key);
+}
+
+GVariant *
+appinfo_to_variant(const appinfo_t *self)
+{
+    GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("a{sv}"));
+
+    auto void add_boolean(const char *label, bool value) {
+        g_variant_builder_add(builder, "{sv}", label,
+                              g_variant_new_boolean(value));
+    }
+
+    auto void add_string(const char *label, const char *value) {
+        if( value && value != appinfo_unknown ) {
+            g_variant_builder_add(builder, "{sv}", label,
+                                  g_variant_new_string(value));
+        }
+    }
+
+    auto void add_stringset(const char *label, const stringset_t *value) {
+        if( value ) {
+            g_variant_builder_add(builder, "{sv}", label,
+                                  stringset_to_variant(value));
+        }
+    }
+
+    if( self ) {
+        add_string("Id", appinfo_id(self));
+
+        /* Desktop properties
+         */
+        add_string(DESKTOP_KEY_NAME, appinfo_get_name(self));
+        add_string(DESKTOP_KEY_TYPE, appinfo_get_type(self));
+        add_string(DESKTOP_KEY_ICON, appinfo_get_icon(self));
+        add_string(DESKTOP_KEY_EXEC, appinfo_get_exec(self));
+        add_boolean(DESKTOP_KEY_NO_DISPLAY, appinfo_get_no_display(self));
+
+        /* Maemo properties
+         */
+        add_string(MAEMO_KEY_SERVICE, appinfo_get_service(self));
+        add_string(MAEMO_KEY_OBJECT, appinfo_get_object(self));
+        add_string(MAEMO_KEY_METHOD, appinfo_get_method(self));
+
+        /* Sailjail properties
+         */
+        add_string(SAILJAIL_KEY_ORGANIZATION_NAME, appinfo_get_organization_name(self));
+        add_string(SAILJAIL_KEY_APPLICATION_NAME, appinfo_get_application_name(self));
+        add_stringset(SAILJAIL_KEY_PERMISSIONS, appinfo_get_permissions(self));
+    }
+
+    GVariant *variant = g_variant_builder_end(builder);
+    g_variant_builder_unref(builder);
+
+    return variant;
+}
+
+gchar *
+appinfo_to_string(const appinfo_t *self)
+{
+    gchar    *string  = NULL;
+    GVariant *variant = appinfo_to_variant(self);
+    if( variant ) {
+        string = g_variant_print(variant, false);
+        g_variant_unref(variant);
+    }
+    return string;
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_ATTRIBUTE
+ * ------------------------------------------------------------------------- */
+
+bool
+appinfo_valid(const appinfo_t *self)
+{
+    return appinfo_get_state(self) == APPINFO_STATE_VALID;
+}
+
+control_t *
+appinfo_control(const appinfo_t *self)
+{
+    return applications_control(appinfo_applications(self));
+}
+
+applications_t *
+appinfo_applications(const appinfo_t *self)
+{
+    return self->anf_applications;
+}
+
+const gchar *
+appinfo_id(const appinfo_t *self)
+{
+    return self->anf_appname;
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PROPERTY
+ * ------------------------------------------------------------------------- */
+
+static void
+appinfo_set_dirty(appinfo_t *self)
+{
+    self->anf_dirty = true;
+}
+
+static bool
+appinfo_clear_dirty(appinfo_t *self)
+{
+    bool was_dirty = self->anf_dirty;
+    self->anf_dirty = false;
+    return was_dirty;
+}
+
+static appinfo_state_t
+appinfo_get_state(const appinfo_t *self)
+{
+    return self ? self->anf_state : APPINFO_STATE_DELETED;
+}
+
+static void
+appinfo_set_state(appinfo_t *self, appinfo_state_t state)
+{
+    if( self->anf_state != state ) {
+        log_debug("appinfo(%s): state: %s -> %s",
+                  appinfo_id(self),
+                  appinfo_state_name[self->anf_state],
+                  appinfo_state_name[state]);
+        self->anf_state = state;
+        appinfo_set_dirty(self);
+    }
+}
+
+/* - - - - - - - - - - - - - - - - - - - *
+ * Getters
+ * - - - - - - - - - - - - - - - - - - - */
+
+const gchar *
+appinfo_get_name(const appinfo_t *self)
+{
+    return self->anf_dt_name ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_type(const appinfo_t *self)
+{
+    return self->anf_dt_type ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_icon(const appinfo_t *self)
+{
+    return self->anf_dt_icon ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_exec(const appinfo_t *self)
+{
+    return self->anf_dt_exec ?: appinfo_unknown;
+}
+
+bool
+appinfo_get_no_display(const appinfo_t *self)
+{
+    return self->anf_dt_no_display;
+}
+
+const gchar *
+appinfo_get_service(const appinfo_t *self)
+{
+    return self->anf_mo_service ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_object(const appinfo_t *self)
+{
+    return self->anf_mo_object ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_method(const appinfo_t *self)
+{
+    return self->anf_mo_method ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_organization_name(const appinfo_t *self)
+{
+    return self->anf_sj_organization_name ?: appinfo_unknown;
+}
+
+const gchar *
+appinfo_get_application_name(const appinfo_t *self)
+{
+    return self->anf_sj_application_name ?: appinfo_unknown;
+}
+
+/* - - - - - - - - - - - - - - - - - - - *
+ * Setters
+ * - - - - - - - - - - - - - - - - - - - */
+
+void
+appinfo_set_name(appinfo_t *self, const gchar *name)
+{
+    if( change_string(&self->anf_dt_name, name) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_type(appinfo_t *self, const gchar *type)
+{
+    if( change_string(&self->anf_dt_type, type) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_icon(appinfo_t *self, const gchar *icon)
+{
+    if( change_string(&self->anf_dt_icon, icon) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_exec(appinfo_t *self, const gchar *exec)
+{
+    if( change_string(&self->anf_dt_exec, exec) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_no_display(appinfo_t *self, bool no_display)
+{
+    if( change_boolean(&self->anf_dt_no_display, no_display) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_service(appinfo_t *self, const gchar *service)
+{
+    if( change_string(&self->anf_mo_service, service) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_object(appinfo_t *self, const gchar *object)
+{
+    if( change_string(&self->anf_mo_object, object) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_method(appinfo_t *self, const gchar *method)
+{
+    if( change_string(&self->anf_mo_method, method) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_organization_name(appinfo_t *self, const gchar *organization_name)
+{
+    if( change_string(&self->anf_sj_organization_name, organization_name) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_set_application_name(appinfo_t *self, const gchar *application_name)
+{
+    if( change_string(&self->anf_sj_application_name, application_name) )
+        appinfo_set_dirty(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+bool
+appinfo_has_permission(const appinfo_t *self, const gchar *perm)
+{
+    return stringset_has_item(appinfo_get_permissions(self), perm);
+}
+
+stringset_t *
+appinfo_get_permissions(const appinfo_t *self)
+{
+    return self->anf_sj_permissions_out;
+}
+
+bool
+appinfo_evaluate_permissions(appinfo_t *self)
+{
+    bool changed = false;
+    const stringset_t *mask = control_available_permissions(appinfo_control(self));
+    stringset_t *temp = stringset_filter_in(self->anf_sj_permissions_in, mask);
+
+    if( stringset_assign(self->anf_sj_permissions_out, temp) )
+        changed = true;
+
+    stringset_delete(temp);
+
+    return changed;
+}
+
+void
+appinfo_set_permissions(appinfo_t *self, const stringset_t *in)
+{
+    stringset_assign(self->anf_sj_permissions_in, in);
+    if( appinfo_evaluate_permissions(self) )
+        appinfo_set_dirty(self);
+}
+
+void
+appinfo_clear_permissions(appinfo_t *self)
+{
+    if( stringset_clear(appinfo_get_permissions(self)) )
+        appinfo_set_dirty(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PARSE
+ * ------------------------------------------------------------------------- */
+
+bool
+appinfo_parse_desktop(appinfo_t *self)
+{
+    GKeyFile  *ini         = NULL;
+    gchar     *path        = NULL;
+    GError    *err         = NULL;
+    gchar    **permissions = NULL;
+
+    path = path_from_desktop_name(appinfo_id(self));
+
+    /* Check if the file has changed since last parse */
+    struct stat st = {};
+    if( stat(path, &st) == -1 ) {
+        log_warning("%s: could not stat: %m", path);
+        if( errno == ENOENT )
+            appinfo_set_state(self, APPINFO_STATE_DELETED);
+        else
+            appinfo_set_state(self, APPINFO_STATE_INVALID);
+        goto EXIT;
+    }
+
+    if( self->anf_dt_ctime == st.st_ctime ) {
+        /* Retain current state */
+        goto EXIT;
+    }
+
+    self->anf_dt_ctime = st.st_ctime;
+
+    /* Read file contents */
+    if( access(path, R_OK) == -1 ) {
+        log_warning("%s: not accessible: %m", path);
+        appinfo_set_state(self, APPINFO_STATE_INVALID);
+        goto EXIT;
+    }
+
+    ini = g_key_file_new();
+    if( !keyfile_load(ini, path) ) {
+        appinfo_set_state(self, APPINFO_STATE_INVALID);
+        goto EXIT;
+    }
+
+    //log_debug("appinfo(%s): updating", appinfo_id(self));
+
+    /* Parse desktop properties
+     */
+    gchar *tmp;
+
+    tmp = keyfile_get_string(ini, DESKTOP_SECTION, DESKTOP_KEY_NAME, 0),
+        appinfo_set_name(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, DESKTOP_SECTION, DESKTOP_KEY_TYPE, 0),
+        appinfo_set_type(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, DESKTOP_SECTION, DESKTOP_KEY_ICON, 0),
+        appinfo_set_icon(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, DESKTOP_SECTION, DESKTOP_KEY_EXEC, 0),
+        appinfo_set_exec(self, tmp),
+        g_free(tmp);
+
+    appinfo_set_no_display(self, keyfile_get_boolean(ini, DESKTOP_SECTION,
+                                                     DESKTOP_KEY_NO_DISPLAY,
+                                                     false));
+
+    /* Parse maemo properties
+     */
+    tmp = keyfile_get_string(ini, MAEMO_SECTION, MAEMO_KEY_SERVICE, 0),
+        appinfo_set_service(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, MAEMO_SECTION, MAEMO_KEY_OBJECT, 0),
+        appinfo_set_object(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, MAEMO_SECTION, MAEMO_KEY_METHOD, 0),
+        appinfo_set_method(self, tmp),
+        g_free(tmp);
+
+    /* Parse sailjail properties
+     */
+    const gchar *group = SAILJAIL_SECTION_PRIMARY;
+    if( !g_key_file_has_group(ini, group) )
+        group = SAILJAIL_SECTION_SECONDARY;
+
+    tmp = keyfile_get_string(ini, group, SAILJAIL_KEY_ORGANIZATION_NAME, 0),
+        appinfo_set_organization_name(self, tmp),
+        g_free(tmp);
+
+    tmp = keyfile_get_string(ini, group, SAILJAIL_KEY_APPLICATION_NAME, 0),
+        appinfo_set_application_name(self, tmp),
+        g_free(tmp);
+
+    stringset_t *set = keyfile_get_stringset(ini, group, SAILJAIL_KEY_PERMISSIONS);
+    appinfo_set_permissions(self, set);
+    stringset_delete(set);
+
+    /* Validate */
+    if( appinfo_get_name(self) != appinfo_unknown &&
+        appinfo_get_type(self) != appinfo_unknown &&
+        appinfo_get_exec(self) != appinfo_unknown )
+        appinfo_set_state(self, APPINFO_STATE_VALID);
+    else
+        appinfo_set_state(self, APPINFO_STATE_INVALID);
+
+EXIT:
+    g_clear_error(&err);
+    g_strfreev(permissions);
+    if( ini )
+        g_key_file_unref(ini);
+    g_free(path);
+
+    return appinfo_clear_dirty(self);
+}

--- a/daemon/appinfo.h
+++ b/daemon/appinfo.h
@@ -1,0 +1,125 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  APPINFO_H_
+# define APPINFO_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct stringset_t    stringset_t;
+typedef struct applications_t applications_t;
+typedef struct appinfo_t      appinfo_t;
+typedef struct config_t       config_t;
+typedef struct control_t      control_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO
+ * ------------------------------------------------------------------------- */
+
+appinfo_t *appinfo_create    (applications_t *applications, const gchar *id);
+void       appinfo_delete    (appinfo_t *self);
+void       appinfo_delete_cb (void *self);
+gboolean   appinfo_equal     (const appinfo_t *self, const appinfo_t *that);
+gboolean   appinfo_equal_cb  (gconstpointer a, gconstpointer b);
+guint      appinfo_hash      (const appinfo_t *self);
+guint      appinfo_hash_cb   (gconstpointer key);
+GVariant  *appinfo_to_variant(const appinfo_t *self);
+gchar     *appinfo_to_string (const appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_ATTRIBUTE
+ * ------------------------------------------------------------------------- */
+
+bool            appinfo_valid       (const appinfo_t *self);
+control_t      *appinfo_control     (const appinfo_t *self);
+applications_t *appinfo_applications(const appinfo_t *self);
+const gchar    *appinfo_id          (const appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PROPERTY
+ * ------------------------------------------------------------------------- */
+
+const gchar *appinfo_get_name             (const appinfo_t *self);
+const gchar *appinfo_get_type             (const appinfo_t *self);
+const gchar *appinfo_get_icon             (const appinfo_t *self);
+const gchar *appinfo_get_exec             (const appinfo_t *self);
+bool         appinfo_get_no_display       (const appinfo_t *self);
+const gchar *appinfo_get_service          (const appinfo_t *self);
+const gchar *appinfo_get_object           (const appinfo_t *self);
+const gchar *appinfo_get_method           (const appinfo_t *self);
+const gchar *appinfo_get_organization_name(const appinfo_t *self);
+const gchar *appinfo_get_application_name (const appinfo_t *self);
+void         appinfo_set_name             (appinfo_t *self, const gchar *name);
+void         appinfo_set_type             (appinfo_t *self, const gchar *type);
+void         appinfo_set_icon             (appinfo_t *self, const gchar *icon);
+void         appinfo_set_exec             (appinfo_t *self, const gchar *exec);
+void         appinfo_set_no_display       (appinfo_t *self, bool no_display);
+void         appinfo_set_service          (appinfo_t *self, const gchar *service);
+void         appinfo_set_object           (appinfo_t *self, const gchar *object);
+void         appinfo_set_method           (appinfo_t *self, const gchar *method);
+void         appinfo_set_organization_name(appinfo_t *self, const gchar *organization_name);
+void         appinfo_set_application_name (appinfo_t *self, const gchar *application_name);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+bool         appinfo_has_permission      (const appinfo_t *self, const gchar *perm);
+stringset_t *appinfo_get_permissions     (const appinfo_t *self);
+bool         appinfo_evaluate_permissions(appinfo_t *self);
+void         appinfo_set_permissions     (appinfo_t *self, const stringset_t *in);
+void         appinfo_clear_permissions   (appinfo_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPINFO_PARSE
+ * ------------------------------------------------------------------------- */
+
+bool appinfo_parse_desktop(appinfo_t *self);
+
+G_END_DECLS
+
+#endif /* APPINFO_H_ */

--- a/daemon/applications.c
+++ b/daemon/applications.c
@@ -1,0 +1,460 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "applications.h"
+
+#include "logging.h"
+#include "control.h"
+#include "stringset.h"
+#include "appinfo.h"
+#include "util.h"
+
+#include <glob.h>
+#include <fnmatch.h>
+
+#include <gio/gio.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+#define APPLICATIONS_RESCAN_DELAY            1000 // [ms]
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS
+ * ------------------------------------------------------------------------- */
+
+static void     applications_ctor     (applications_t *self, control_t *control);
+static void     applications_dtor     (applications_t *self);
+applications_t *applications_create   (control_t *control);
+void            applications_delete   (applications_t *self);
+void            applications_delete_at(applications_t **pself);
+void            applications_delete_cb(void *self);
+void            applications_rethink  (applications_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t         *applications_control  (const applications_t *self);
+const stringset_t *applications_available(applications_t *self);
+appinfo_t         *applications_appinfo  (applications_t *self, const char *appname);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void applications_notify_changed(applications_t *self, GHashTable *changed);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_MONITOR
+ * ------------------------------------------------------------------------- */
+
+static void applications_start_monitor(applications_t *self);
+static void applications_stop_monitor (applications_t *self);
+static bool applications_monitor_p    (const gchar *path);
+static void applications_monitor_cb   (GFileMonitor *mon, GFile *file1, GFile *file2, GFileMonitorEvent event, gpointer aptr);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_SCAN
+ * ------------------------------------------------------------------------- */
+
+static void     applications_scan_now     (applications_t *self);
+static gboolean applications_rescan_cb    (gpointer aptr);
+static void     applications_rescan_later (applications_t *self);
+static bool     applications_cancel_rescan(applications_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_APPINFO
+ * ------------------------------------------------------------------------- */
+
+static appinfo_t *applications_get_appinfo   (const applications_t *self, const char *appname);
+static appinfo_t *applications_add_appinfo   (applications_t *self, const char *appname);
+static bool       applications_remove_appinfo(applications_t *self, const char *appname);
+
+/* ========================================================================= *
+ * APPLICATIONS
+ * ========================================================================= */
+
+struct applications_t
+{
+    bool                   aps_initialized;
+    control_t             *aps_control;
+    stringset_t           *aps_available;
+    guint                  aps_rescan_id;
+    GFileMonitor          *aps_monitor_obj;
+    GHashTable            *aps_appinfo_lut;
+};
+
+static void
+applications_ctor(applications_t *self, control_t *control)
+{
+    log_info("applications() create");
+
+    self->aps_initialized = false;
+    self->aps_control     = control;
+    self->aps_available   = stringset_create();
+    self->aps_rescan_id   = 0;
+    self->aps_monitor_obj = NULL;
+    self->aps_appinfo_lut = g_hash_table_new_full(g_str_hash,
+                                                  g_str_equal,
+                                                  g_free,
+                                                  appinfo_delete_cb);
+
+    /* Fetch initial state */
+    applications_start_monitor(self);
+    applications_scan_now(self);
+
+    self->aps_initialized = true;
+}
+
+static  void
+applications_dtor(applications_t *self)
+{
+    log_info("applications() delete");
+
+    self->aps_initialized = false;
+
+    applications_stop_monitor(self);
+    applications_cancel_rescan(self);
+
+    if( self->aps_appinfo_lut ) {
+        g_hash_table_unref(self->aps_appinfo_lut),
+            self->aps_appinfo_lut = NULL;
+    }
+
+    stringset_delete_at(&self->aps_available);
+}
+
+applications_t *
+applications_create(control_t *control)
+{
+    applications_t *self = g_malloc0(sizeof *self);
+    applications_ctor(self, control);
+    return self;
+}
+
+void
+applications_delete(applications_t *self)
+{
+    if( self ) {
+        applications_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+applications_delete_at(applications_t **pself)
+{
+    applications_delete(*pself), *pself = NULL;
+}
+
+void
+applications_delete_cb(void *self)
+{
+    applications_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t *
+applications_control(const applications_t *self)
+{
+    return self->aps_control;
+}
+
+const stringset_t *
+applications_available(applications_t *self)
+{
+    if( applications_cancel_rescan(self) )
+        applications_scan_now(self);
+    return self->aps_available;
+}
+
+appinfo_t *
+applications_appinfo(applications_t *self, const char *appname)
+{
+    appinfo_t *appinfo = applications_get_appinfo(self, appname);
+    /* Do not expose removed/invalid desktop file
+     * placeholders outside applications module.
+     */
+    return appinfo_valid(appinfo) ? appinfo : NULL;
+}
+
+#ifdef DEAD_CODE
+static const config_t *
+applications_config(const applications_t *self)
+{
+    return control_config(applications_control(self));
+}
+#endif
+
+/* ========================================================================= *
+ * APPLICATIONS_NOTIFY
+ * ========================================================================= */
+
+static void
+applications_notify_changed(applications_t *self, GHashTable *changed)
+{
+    if( self->aps_initialized )
+        control_on_application_change(applications_control(self), changed);
+}
+
+/* ========================================================================= *
+ * APPLICATIONS_MONITOR
+ * ========================================================================= */
+
+static void
+applications_start_monitor(applications_t *self)
+{
+    applications_stop_monitor(self);
+
+    GFileMonitorFlags flags = G_FILE_MONITOR_WATCH_MOVES;
+    GFile *file = g_file_new_for_path(APPLICATIONS_DIRECTORY);
+    if( file ) {
+        if( (self->aps_monitor_obj = g_file_monitor_directory(file, flags, 0, 0)) ) {
+            g_signal_connect(self->aps_monitor_obj, "changed",
+                             G_CALLBACK(applications_monitor_cb), self);
+            log_info("APPLICATIONS MONITOR: started");
+        }
+        g_object_unref(file);
+    }
+}
+
+static void
+applications_stop_monitor(applications_t *self)
+{
+    if( self->aps_monitor_obj ) {
+        log_info("APPLICATIONS MONITOR: stopped");
+        g_object_unref(self->aps_monitor_obj),
+            self->aps_monitor_obj = NULL;
+    }
+}
+
+static bool
+applications_monitor_p(const gchar *path)
+{
+    path = path_basename(path);
+    return path && fnmatch(APPLICATIONS_PATTERN, path, FNM_PATHNAME) == 0;
+}
+
+static void
+applications_monitor_cb(GFileMonitor      *mon,
+                        GFile             *file1,
+                        GFile             *file2,
+                        GFileMonitorEvent  event,
+                        gpointer           aptr)
+{
+    applications_t *self = aptr;
+
+    const char *path1 = file1 ? g_file_peek_path(file1) : NULL;
+    const char *path2 = file2 ? g_file_peek_path(file2) : NULL;
+    bool trigger = (applications_monitor_p(path1) ||
+                    applications_monitor_p(path2));
+
+    if( trigger ) {
+        log_info("APPLICATIONS MONITOR: trigger @ %s %s", path1, path2);
+        applications_rescan_later(self);
+    }
+}
+
+/* ========================================================================= *
+ * APPLICATIONS_SCAN
+ * ========================================================================= */
+
+void
+applications_rethink(applications_t *self)
+{
+    GHashTable *changed = g_hash_table_new_full(g_str_hash, g_str_equal,
+                                                g_free, NULL);
+
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, self->aps_appinfo_lut);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        if( appinfo_evaluate_permissions(value) )
+            g_hash_table_add(changed, g_strdup(key));
+    }
+
+    if( g_hash_table_size(changed) > 0 )
+        applications_notify_changed(self, changed);
+
+    g_hash_table_unref(changed);
+}
+
+static void
+applications_scan_now(applications_t *self)
+{
+    glob_t      gl      = {};
+    GHashTable *scanned = NULL;
+    GHashTable *changed = NULL;
+
+    applications_cancel_rescan(self);
+
+    log_info("APPLICATIONS RESCAN: executing");
+
+    if( glob(APPLICATIONS_DIRECTORY "/" APPLICATIONS_PATTERN, 0, 0, &gl) != 0 ) {
+        /* Keep current data */
+        goto EXIT;
+    }
+
+    scanned = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+    for( int i = 0; i < gl.gl_pathc; ++i ) {
+        gchar *appname = path_to_desktop_name(gl.gl_pathv[i]);
+        g_hash_table_add(scanned, appname);
+    }
+
+    changed = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+
+    GHashTableIter iter;
+    gpointer key, value;
+
+    /* Find out entries that no longer exist */
+    g_hash_table_iter_init(&iter, self->aps_appinfo_lut);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        if( !g_hash_table_lookup(scanned, key) )
+            g_hash_table_add(changed, g_strdup(key));
+    }
+
+    /* Flush removed entries from bookkeeping */
+    g_hash_table_iter_init(&iter, changed);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        log_debug("APPLICATIONS RESCAN: remove: %s", (char *)key);
+        applications_remove_appinfo(self, key);
+    }
+
+    /* Update existing / new entries */
+    g_hash_table_iter_init(&iter, scanned);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        //log_debug("APPLICATIONS RESCAN: update: %s", (char *)key);
+        appinfo_t *appinfo = applications_add_appinfo(self, key);
+        if( appinfo_parse_desktop(appinfo) )
+            g_hash_table_add(changed, g_strdup(key));
+    }
+
+    /* Update available list */
+    stringset_clear(self->aps_available);
+    g_hash_table_iter_init(&iter, self->aps_appinfo_lut);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        if( appinfo_valid(value) )
+            stringset_add_item(self->aps_available, key);
+    }
+
+    /* Notify upwards, receiver can ref() if needed */
+    if( g_hash_table_size(changed) > 0 )
+        applications_notify_changed(self, changed);
+
+EXIT:
+    if( changed )
+        g_hash_table_unref(changed);
+    if( scanned )
+        g_hash_table_unref(scanned);
+    globfree(&gl);
+}
+
+static gboolean
+applications_rescan_cb(gpointer aptr)
+{
+    applications_t *self = aptr;
+
+    self->aps_rescan_id = 0;
+
+    log_info("APPLICATIONS RESCAN: triggered");
+    applications_scan_now(self);
+
+    return G_SOURCE_REMOVE;
+}
+
+static void
+applications_rescan_later(applications_t *self)
+{
+    if( !self->aps_rescan_id )
+        log_info("APPLICATIONS RESCAN: scheduled");
+    else
+        g_source_remove(self->aps_rescan_id);
+    self->aps_rescan_id = g_timeout_add(APPLICATIONS_RESCAN_DELAY,
+                                        applications_rescan_cb, self);
+}
+
+static bool
+applications_cancel_rescan(applications_t *self)
+{
+    bool canceled = false;
+    if( self->aps_rescan_id ) {
+        log_info("APPLICATIONS RESCAN: canceled");
+        g_source_remove(self->aps_rescan_id),
+            self->aps_rescan_id = 0;
+        canceled = true;
+    }
+    return canceled;
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_APPINFO
+ * ------------------------------------------------------------------------- */
+
+static appinfo_t *
+applications_get_appinfo(const applications_t *self, const char *appname)
+{
+    return g_hash_table_lookup(self->aps_appinfo_lut, appname);
+}
+
+static appinfo_t *
+applications_add_appinfo(applications_t *self, const char *appname)
+{
+    appinfo_t *appinfo = applications_get_appinfo(self, appname);
+    if( !appinfo ) {
+        appinfo = appinfo_create(self, appname);
+        g_hash_table_insert(self->aps_appinfo_lut, g_strdup(appname), appinfo);
+    }
+    return appinfo;
+}
+
+static bool
+applications_remove_appinfo(applications_t *self, const char *appname)
+{
+    return g_hash_table_remove(self->aps_appinfo_lut, appname);
+}

--- a/daemon/applications.h
+++ b/daemon/applications.h
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  APPLICATIONS_H_
+# define APPLICATIONS_H_
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t       config_t;
+typedef struct stringset_t    stringset_t;
+typedef struct applications_t applications_t;
+typedef struct appinfo_t      appinfo_t;
+typedef struct control_t      control_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS
+ * ------------------------------------------------------------------------- */
+
+applications_t *applications_create   (control_t *control);
+void            applications_delete   (applications_t *self);
+void            applications_delete_at(applications_t **pself);
+void            applications_delete_cb(void *self);
+void            applications_rethink  (applications_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPLICATIONS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t         *applications_control  (const applications_t *self);
+const stringset_t *applications_available(applications_t *self);
+appinfo_t         *applications_appinfo  (applications_t *self, const char *appname);
+
+G_END_DECLS
+
+#endif /* APPLICATIONS_H_ */

--- a/daemon/config.c
+++ b/daemon/config.c
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "config.h"
+
+#include "util.h"
+#include "logging.h"
+
+#include <glob.h>
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t config_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * CONFIG
+ * ------------------------------------------------------------------------- */
+
+static void  config_ctor     (config_t *self);
+static void  config_dtor     (config_t *self);
+config_t    *config_create   (void);
+void         config_delete   (config_t *self);
+void         config_delete_at(config_t **pself);
+void         config_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONFIG_LOAD
+ * ------------------------------------------------------------------------- */
+
+static void config_unload(config_t *self);
+static void config_load  (config_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONFIG_VALUE
+ * ------------------------------------------------------------------------- */
+
+bool   config_boolean(const config_t *self, const gchar *sec, const gchar *key, bool def);
+gint   config_integer(const config_t *self, const gchar *sec, const gchar *key, gint def);
+gchar *config_string (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+
+/* ========================================================================= *
+ * CONFIG
+ * ========================================================================= */
+
+struct config_t
+{
+    GKeyFile *cfg_keyfile;
+};
+
+static void
+config_ctor(config_t *self)
+{
+    log_info("config() created");
+    self->cfg_keyfile = NULL;
+    config_load(self);
+}
+
+static void
+config_dtor(config_t *self)
+{
+    log_info("config() deleted");
+    config_unload(self);
+}
+
+config_t *
+config_create(void)
+{
+    config_t *self = g_malloc0(sizeof *self);
+    config_ctor(self);
+    return self;
+}
+
+void
+config_delete(config_t *self)
+{
+    if( self ) {
+        config_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+config_delete_at(config_t **pself)
+{
+    config_delete(*pself), *pself = NULL;
+}
+
+void
+config_delete_cb(void *self)
+{
+    config_delete(self);
+}
+
+static void
+config_unload(config_t *self)
+{
+    if( self->cfg_keyfile ) {
+        g_key_file_unref(self->cfg_keyfile),
+            self->cfg_keyfile = NULL;
+    }
+}
+
+static void
+config_load(config_t *self)
+{
+    glob_t gl = {};
+
+    config_unload(self);
+
+    self->cfg_keyfile = g_key_file_new();
+
+    if( glob(CONFIG_DIRECTORY "/" CONFIG_PATTERN, 0, 0, &gl) != 0 )
+        goto EXIT;
+
+    for( int i = 0; i < gl.gl_pathc; ++i )
+        keyfile_merge(self->cfg_keyfile, gl.gl_pathv[i]);
+
+EXIT:
+    globfree(&gl);
+}
+
+bool
+config_boolean(const config_t *self, const gchar *sec, const gchar *key,
+               bool def)
+{
+    return keyfile_get_boolean(self->cfg_keyfile, sec, key, def);
+}
+
+gint
+config_integer(const config_t *self, const gchar *sec, const gchar *key,
+               gint def)
+{
+    return keyfile_get_integer(self->cfg_keyfile, sec, key, def);
+}
+
+gchar *
+config_string(const config_t *self, const gchar *sec, const gchar *key,
+              const gchar *def)
+{
+    return keyfile_get_string(self->cfg_keyfile, sec, key, def);
+}

--- a/daemon/config.h
+++ b/daemon/config.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  CONFIG_H_
+# define CONFIG_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t config_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * CONFIG
+ * ------------------------------------------------------------------------- */
+
+config_t *config_create   (void);
+void      config_delete   (config_t *self);
+void      config_delete_at(config_t **pself);
+void      config_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONFIG_VALUE
+ * ------------------------------------------------------------------------- */
+
+bool   config_boolean(const config_t *self, const gchar *sec, const gchar *key, bool def);
+gint   config_integer(const config_t *self, const gchar *sec, const gchar *key, gint def);
+gchar *config_string (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+
+G_END_DECLS
+
+#endif /* CONFIG_H_ */

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -1,0 +1,425 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "control.h"
+
+#include "logging.h"
+#include "users.h"
+#include "permissions.h"
+#include "stringset.h"
+#include "session.h"
+#include "applications.h"
+#include "settings.h"
+#include "service.h"
+#include "later.h"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t config_t;
+typedef struct control_t control_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL
+ * ------------------------------------------------------------------------- */
+
+static void  control_ctor     (control_t *self, const config_t *config);
+static void  control_dtor     (control_t *self);
+control_t   *control_create   (const config_t *config);
+void         control_delete   (control_t *self);
+void         control_delete_at(control_t **pself);
+void         control_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+const config_t    *control_config                (const control_t *self);
+users_t           *control_users                 (const control_t *self);
+session_t         *control_session               (const control_t *self);
+permissions_t     *control_permissions           (const control_t *self);
+applications_t    *control_applications          (const control_t *self);
+service_t         *control_service               (const control_t *self);
+settings_t        *control_settings              (const control_t *self);
+appsettings_t     *control_appsettings           (control_t *self, uid_t uid, const char *app);
+appinfo_t         *control_appinfo               (const control_t *self, const char *appname);
+uid_t              control_current_user          (const control_t *self);
+bool               control_valid_user            (const control_t *self, uid_t uid);
+uid_t              control_min_user              (const control_t *self);
+uid_t              control_max_user              (const control_t *self);
+const stringset_t *control_available_permissions (const control_t *self);
+bool               control_valid_permission      (const control_t *self, const char *perm);
+const stringset_t *control_available_applications(const control_t *self);
+bool               control_valid_application     (const control_t *self, const char *appname);
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_SLOTS
+ * ------------------------------------------------------------------------- */
+
+void control_on_users_changed     (control_t *self);
+void control_on_session_changed   (control_t *self);
+void control_on_permissions_change(control_t *self);
+void control_on_application_change(control_t *self, GHashTable *changed);
+void control_on_settings_change   (control_t *self, const char *app);
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void control_rethink_applications_cb(gpointer aptr);
+static void control_rethink_settings_cb    (gpointer aptr);
+static void control_rethink_broadcast_cb   (gpointer aptr);
+
+/* ========================================================================= *
+ * CONTROL
+ * ========================================================================= */
+
+struct control_t
+{
+    const config_t *ctl_config;
+
+    stringset_t    *ctl_changed_applications;
+    later_t        *ctl_rethink_applications;
+    later_t        *ctl_rethink_settings;
+    later_t        *ctl_rethink_broadcast;
+
+    users_t        *ctl_users;
+    session_t      *ctl_session;
+    permissions_t  *ctl_permissions;
+    applications_t *ctl_applications;
+    settings_t     *ctl_settings;
+    service_t      *ctl_service;
+};
+
+/* ========================================================================= *
+ * CONTROL
+ * ========================================================================= */
+
+static void
+control_ctor(control_t *self, const config_t *config)
+{
+    log_info("control() create");
+    self->ctl_config = config;
+
+    /* Init re-evaluation pipeline */
+    self->ctl_changed_applications = stringset_create();
+    self->ctl_rethink_applications =
+        later_create("applications", 0, 0,
+                     control_rethink_applications_cb, self);
+    self->ctl_rethink_settings =
+        later_create("settings", 10, 0,
+                     control_rethink_settings_cb, self);
+    self->ctl_rethink_broadcast  =
+        later_create("broadcast", 20, 0,
+                     control_rethink_broadcast_cb, self);
+
+    /* Init data tracking */
+    self->ctl_users        = users_create(self);
+    self->ctl_session      = session_create(self);
+    self->ctl_permissions  = permissions_create(self);
+    self->ctl_applications = applications_create(self);
+    self->ctl_settings     = settings_create(config, self);
+
+    /* Init D-Bus service */
+    self->ctl_service      = service_create(self);
+}
+
+static void
+control_dtor(control_t *self)
+{
+    log_info("control() delete");
+
+    /* Quit D-Bus service */
+    service_delete_at(&self->ctl_service);
+
+    /* Quit data tracking */
+    settings_delete_at(&self->ctl_settings);
+    applications_delete_at(&self->ctl_applications);
+    permissions_delete_at(&self->ctl_permissions);
+    session_delete_at(&self->ctl_session);
+    users_delete_at(&self->ctl_users);
+
+    /* Quit re-evaluation pipeline */
+    later_delete_at(&self->ctl_rethink_broadcast);
+    later_delete_at(&self->ctl_rethink_settings);
+    later_delete_at(&self->ctl_rethink_applications);
+    stringset_delete_at(&self->ctl_changed_applications);
+}
+
+control_t *
+control_create(const config_t *config)
+{
+    control_t *self = g_malloc0(sizeof *self);
+    control_ctor(self, config);
+    return self;
+}
+
+void
+control_delete(control_t *self)
+{
+    if( self ) {
+        control_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+control_delete_at(control_t **pself)
+{
+    control_delete(*pself), *pself = NULL;
+}
+
+void
+control_delete_cb(void *self)
+{
+    control_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+const config_t *
+control_config(const control_t *self)
+{
+    return self->ctl_config;
+}
+
+users_t *
+control_users(const control_t *self)
+{
+    return self->ctl_users;
+}
+
+session_t *
+control_session(const control_t *self)
+{
+    return self->ctl_session;
+}
+
+permissions_t *
+control_permissions(const control_t *self)
+{
+    return self->ctl_permissions;
+}
+
+applications_t *
+control_applications(const control_t *self)
+{
+    return self->ctl_applications;
+}
+
+service_t *
+control_service(const control_t *self)
+{
+    return self->ctl_service;
+}
+
+settings_t *
+control_settings(const control_t *self)
+{
+    return self->ctl_settings;
+}
+
+appsettings_t *
+control_appsettings(control_t *self, uid_t uid, const char *app)
+{
+    return settings_appsettings(control_settings(self), uid, app);
+}
+
+appinfo_t *
+control_appinfo(const control_t *self, const char *appname)
+{
+    return applications_appinfo(control_applications(self), appname);
+}
+
+uid_t
+control_current_user(const control_t *self)
+{
+    return session_current_user(control_session(self));
+}
+
+bool
+control_valid_user(const control_t *self, uid_t uid)
+{
+    return users_user_exists(control_users(self), uid);
+}
+
+uid_t
+control_min_user(const control_t *self)
+{
+    return users_first_user(control_users(self));
+}
+
+uid_t
+control_max_user(const control_t *self)
+{
+    return users_last_user(control_users(self));
+}
+
+const stringset_t *
+control_available_permissions(const control_t *self)
+{
+    return permissions_available(control_permissions(self));
+}
+
+bool
+control_valid_permission(const control_t *self, const char *perm)
+{
+    return stringset_has_item(control_available_permissions(self), perm);
+}
+
+const stringset_t *
+control_available_applications(const control_t *self)
+{
+    return applications_available(control_applications(self));
+}
+
+bool
+control_valid_application(const control_t *self, const char *appname)
+{
+    return stringset_has_item(control_available_applications(self), appname);
+}
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_SLOTS
+ * ------------------------------------------------------------------------- */
+
+void
+control_on_users_changed(control_t *self)
+{
+    log_notice("*** users changed notification");
+
+    users_t *users = control_users(self);
+    uid_t first = users_first_user(users);
+    uid_t last  = users_last_user(users);
+
+    for( uid_t uid = first; uid <= last; ++uid ) {
+        log_notice("uid[%u] = %s",
+                   (unsigned)uid,
+                   users_user_exists(users, uid) ? "exists" : "n/a");
+    }
+}
+
+void
+control_on_session_changed(control_t *self)
+{
+    log_notice("*** session changed notification");
+
+    session_t *session = control_session(self);
+
+    uid_t uid = session_current_user(session);
+    log_notice("session uid = %d", (int)uid);
+}
+
+void
+control_on_permissions_change(control_t *self)
+{
+    log_notice("*** permissions changed notification");
+
+    permissions_t *permissions = control_permissions(self);
+    gchar *perms = stringset_to_string(permissions_available(permissions));
+    log_notice("available permissions = %s", perms);
+    g_free(perms);
+
+    later_schedule(self->ctl_rethink_applications);
+    // -> control_rethink_applications_cb()
+}
+
+void
+control_on_application_change(control_t *self, GHashTable *changed)
+{
+    log_notice("*** applications changed notification");
+
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, changed);
+    while( g_hash_table_iter_next(&iter, &key, &value) ){
+        log_debug("application change: %s", (char *)key);
+        stringset_add_item(self->ctl_changed_applications, key);
+    }
+
+    later_schedule(self->ctl_rethink_settings);
+    // -> control_rethink_settings_cb()
+    later_schedule(self->ctl_rethink_broadcast);
+    // -> control_rethink_broadcast_cb()
+}
+
+void
+control_on_settings_change(control_t *self, const char *app)
+{
+    log_notice("*** settings changed notification: %s", app);
+    stringset_add_item(self->ctl_changed_applications, app);
+    later_schedule(self->ctl_rethink_broadcast);
+    // -> control_rethink_broadcast_cb()
+}
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void
+control_rethink_applications_cb(gpointer aptr)
+{
+    log_notice("*** rethink applications data");
+    control_t *self = aptr;
+    applications_rethink(control_applications(self));
+    // -> control_on_application_change()
+}
+
+static void
+control_rethink_settings_cb(gpointer aptr)
+{
+    log_notice("*** rethink settings data");
+    control_t *self = aptr;
+    settings_rethink(control_settings(self));
+    // -> control_on_settings_change()
+}
+
+static void
+control_rethink_broadcast_cb(gpointer aptr)
+{
+    log_notice("*** rethink broadcast data");
+    control_t *self = aptr;
+    service_applications_changed(control_service(self),
+                                 self->ctl_changed_applications);
+    stringset_clear(self->ctl_changed_applications);
+}

--- a/daemon/control.h
+++ b/daemon/control.h
@@ -1,0 +1,108 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  CONTROL_H_
+# define CONTROL_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct stringset_t    stringset_t;
+typedef struct config_t       config_t;
+typedef struct users_t        users_t;
+typedef struct session_t      session_t;
+typedef struct permissions_t  permissions_t;
+typedef struct applications_t applications_t;
+typedef struct control_t      control_t;
+typedef struct service_t      service_t;
+typedef struct appinfo_t      appinfo_t;
+typedef struct settings_t     settings_t;
+typedef struct appsettings_t  appsettings_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL
+ * ------------------------------------------------------------------------- */
+
+control_t *control_create   (const config_t *config);
+void       control_delete   (control_t *self);
+void       control_delete_at(control_t **pself);
+void       control_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+const config_t    *control_config                (const control_t *self);
+users_t           *control_users                 (const control_t *self);
+session_t         *control_session               (const control_t *self);
+permissions_t     *control_permissions           (const control_t *self);
+applications_t    *control_applications          (const control_t *self);
+service_t         *control_service               (const control_t *self);
+settings_t        *control_settings              (const control_t *self);
+appsettings_t     *control_appsettings           (control_t *self, uid_t uid, const char *app);
+appinfo_t         *control_appinfo               (const control_t *self, const char *appname);
+uid_t              control_current_user          (const control_t *self);
+bool               control_valid_user            (const control_t *self, uid_t uid);
+uid_t              control_min_user              (const control_t *self);
+uid_t              control_max_user              (const control_t *self);
+const stringset_t *control_available_permissions (const control_t *self);
+bool               control_valid_permission      (const control_t *self, const char *perm);
+const stringset_t *control_available_applications(const control_t *self);
+bool               control_valid_application     (const control_t *self, const char *appname);
+
+/* ------------------------------------------------------------------------- *
+ * CONTROL_SLOTS
+ * ------------------------------------------------------------------------- */
+
+void control_on_users_changed     (control_t *self);
+void control_on_session_changed   (control_t *self);
+void control_on_permissions_change(control_t *self);
+void control_on_application_change(control_t *self, GHashTable *changed);
+void control_on_settings_change   (control_t *self, const char *app);
+
+G_END_DECLS
+
+#endif /* CONTROL_H_ */

--- a/daemon/dataflow.dot
+++ b/daemon/dataflow.dot
@@ -1,0 +1,105 @@
+/* -*- mode: c -*- */
+digraph foo {
+  //rankdir=LR;
+  node[shape=box];
+  node[style=filled]
+  node[fillcolor=wheat];
+  node[width=0.001];
+  node[height=0.001];
+  node[fontsize=8];
+
+  edge[fontsize=7];
+  edge[color=grey30];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * SOURCES
+   * - - - - - - - - - - - - - - - - - - - */
+  node[fillcolor=GreenYellow];
+
+  PERMISSION_FILES [label="Permission\nFiles"];
+  DESKTOP_FILES    [label="Desktop\nFiles"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * STATE DATA
+   * - - - - - - - - - - - - - - - - - - - */
+  node[fillcolor=cyan];
+
+  ChangedApplications [label="Changed Applications"];
+  APPLICATION_DB      [label="Application Data"];
+  PERMISSION_DB       [label="Permission Data"];
+  SETTINGS_DB         [label="Setting Data"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * SIGNALS
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[fillcolor=SlateGray1];
+  ApplicationAdded
+  ApplicationRemoved
+  ApplicationChanged
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * TRIGGERS
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[shape=oval];
+  node[fillcolor=yellow];
+
+  PERMISSION_CHANGE  [label="Permission\nChange"];
+  APPLICATION_CHANGE [label="Application\nChange"];
+  SETTINGS_CHANGE    [label="Settings\nChange"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * ACTIONS
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[fillcolor=wheat];
+
+  SETTINGS_RETHINK     [label="Settings\nRethink"];
+  APPLICATIONS_RETHINK [label="Applications\nRethink"];
+  BROADCAST_RETHINK    [label="Broadcast\nRethink"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * DATAFLOWS (SYNC)
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[fillcolor=pink];
+  edge[color=grey30];
+
+  {ChangedApplications APPLICATION_DB } -> BROADCAST_RETHINK
+
+  SETTINGS_CHANGE -> ChangedApplications;
+
+  APPLICATION_CHANGE -> ChangedApplications;
+  APPLICATIONS_RETHINK -> APPLICATION_DB;
+  PERMISSION_CHANGE -> PERMISSION_DB;
+
+  PERMISSION_DB -> SETTINGS_RETHINK;
+  APPLICATION_DB -> SETTINGS_RETHINK;
+  PERMISSION_DB ->  APPLICATIONS_RETHINK;
+  SETTINGS_RETHINK -> SETTINGS_DB;
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * DATAFLOWS (ASYNC)
+   * - - - - - - - - - - - - - - - - - - - */
+  edge[color=blue, style=dotted];
+
+  SETTINGS_CHANGE    -> BROADCAST_RETHINK;
+  SETTINGS_RETHINK -> SETTINGS_CHANGE;
+  PERMISSION_FILES->PERMISSION_CHANGE;
+  APPLICATION_CHANGE -> SETTINGS_RETHINK;
+  APPLICATION_CHANGE -> BROADCAST_RETHINK;
+  DESKTOP_FILES -> APPLICATION_CHANGE;
+  PERMISSION_CHANGE -> SETTINGS_RETHINK;
+  PERMISSION_CHANGE -> APPLICATIONS_RETHINK;
+
+  //APPLICATIONS_RETHINK -> APPLICATION_CHANGE;
+  APPLICATION_CHANGE -> APPLICATIONS_RETHINK;
+
+  BROADCAST_RETHINK -> {
+    ApplicationAdded
+    ApplicationRemoved
+    ApplicationChanged
+  }
+
+}

--- a/daemon/dbus/sailjaild.conf
+++ b/daemon/dbus/sailjaild.conf
@@ -1,0 +1,20 @@
+<!DOCTYPE busconfig PUBLIC
+ "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+  "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<busconfig>
+	<policy user="root">
+		<allow own="org.sailfishos.sailjaild1"/>
+		<allow send_destination="org.sailfishos.sailjaild1"
+		       send_interface="org.sailfishos.sailjaild1"/>
+	</policy>
+
+	<policy context="default">
+		<allow send_destination="org.sailfishos.sailjaild1"
+		       send_interface="org.freedesktop.DBus.Introspectable"/>
+		<allow send_destination="org.sailfishos.sailjaild1"
+		       send_interface="org.freedesktop.DBus.Peer"/>
+		<allow send_destination="org.sailfishos.sailjaild1"
+		       send_interface="org.sailfishos.sailjaild1"/>
+	</policy>
+</busconfig>

--- a/daemon/depend_filter.py
+++ b/daemon/depend_filter.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+# -*- encoding: utf8 -*-
+
+#######################################################################################
+#
+# Copyright (C) 2012 - 2021 Jolla Ltd.
+#
+# Author: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+#
+# All rights reserved.
+#
+# You may use this file under the terms of the GNU Lesser General
+# Public License version 2.1 as published by the Free Software Foundation
+# and appearing in the file license.lgpl included in the packaging
+# of this file.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 2.1 as published by the Free Software Foundation
+# and appearing in the file license.lgpl included in the packaging
+# of this file.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+#######################################################################################
+
+import sys,os
+
+def is_local(path):
+    return not path.startswith("/")
+
+def print_rule(dest, srce):
+    print("%s\\\n" % "\\\n\t".join(["%s:" % dest] + srce))
+
+def set_extension(path, ext):
+    return os.path.splitext(path)[0] + ext
+
+def normalize_path(srce):
+    return os.path.normpath(srce)
+
+def fix_directory(dest, srce):
+    srce = os.path.dirname(srce)
+    dest = os.path.basename(dest)
+    return os.path.join(srce, dest)
+
+if __name__ == "__main__":
+
+    data = sys.stdin.readlines()
+    data = list(map(lambda x:x.rstrip(), data))
+    data.reverse()
+
+    deps = []
+
+    # Note: dependencies are sorted only to keep
+    #       future diffs cleaner
+
+    while data:
+        line = data.pop()
+        while line.endswith('\\'):
+            line = line[:-1] + data.pop()
+        if not ':' in line:
+            continue
+
+        dest,srce = line.split(":",1)
+        srce = srce.split()
+        srce,temp = srce[0],srce[1:]
+
+        # take dest path primary srce
+        dest = fix_directory(dest, srce)
+
+        # remove secondary deps with absolute path
+        temp = list(filter(is_local, temp))
+
+        # sort secondary sources
+        temp.sort()
+
+        srce = [srce] + temp
+        srce = list(map(normalize_path, srce))
+
+        deps.append((dest,srce))
+
+    for dest,srce in sorted(deps):
+        # emit normal compilation dependencies
+        print_rule(dest, srce)
+        # and for -fPIC in case it is needed
+        dest = set_extension(dest, ".pic.o")
+        print_rule(dest, srce)

--- a/daemon/desktop_data.c
+++ b/daemon/desktop_data.c
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "util.h"
+
+#include <stdio.h>
+
+int main(int ac, char **av)
+{
+    if( ac < 2 ) {
+        fprintf(stderr,
+                "USAGE:\n"
+                "     %s /usr/share/applications/*.desktop\n"
+                "\n"
+                "DESCRIPTION:\n"
+                "     Merges data from all given desktop files and\n"
+                "     outputs the result.\n"
+                "\n"
+                "     Can be used for quickly checking what kinds of\n"
+                "     Key=Value pairs are used in desktop files\n",
+                *av);
+        return EXIT_FAILURE;
+    }
+
+    GKeyFile *keyfile = g_key_file_new();
+
+    for( int i = 1; i < ac; ++i )
+        keyfile_merge(keyfile, av[i]);
+
+    gchar *text = g_key_file_to_data(keyfile, NULL, NULL);
+    printf("%s\n", text);
+
+    g_free(text);
+    g_key_file_unref(keyfile);
+
+    return EXIT_SUCCESS;
+}

--- a/daemon/later.c
+++ b/daemon/later.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "later.h"
+
+#include "logging.h"
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+later_t         *later_create    (const char *label, gint priority, guint delay, later_func_t func, gpointer aptr);
+void             later_delete    (later_t *self);
+void             later_delete_at (later_t **pself);
+void             later_schedule  (later_t *self);
+void             later_cancel    (later_t *self);
+void             later_execute   (later_t *self);
+static gboolean  later_trigger_cb(gpointer aptr);
+
+/* ========================================================================= *
+ * LATER
+ * ========================================================================= */
+
+struct later_t
+{
+    const char  *label;
+    gint         priority;
+    guint        delay;
+    later_func_t func;
+    gpointer     aptr;
+    guint        id;
+};
+
+later_t *
+later_create(const char *label, gint priority, guint delay,
+             later_func_t func, gpointer aptr)
+{
+    later_t *self = g_malloc0(sizeof *self);
+
+    self->label    = label;
+    self->priority = priority;
+    self->delay    = delay;
+    self->func     = func;
+    self->aptr     = aptr;
+    self->id       = 0;
+
+    return self;
+}
+
+void
+later_delete(later_t *self)
+{
+    if( self ) {
+        later_cancel(self);
+        g_free(self);
+    }
+}
+
+void
+later_delete_at(later_t **pself)
+{
+    later_delete(*pself), *pself = NULL;
+}
+
+void
+later_schedule(later_t *self)
+{
+    if( !self->id ) {
+        log_debug("later(%s) scheduled", self->label);
+        if( self->delay )
+            self->id = g_timeout_add_full(self->priority,
+                                          self->delay,
+                                          later_trigger_cb,
+                                          self, NULL);
+        else
+            self->id = g_idle_add_full(self->priority,
+                                       later_trigger_cb,
+                                       self, NULL);
+    }
+}
+
+void
+later_cancel(later_t *self)
+{
+    if( self->id ) {
+        log_debug("later(%s) cancelled", self->label);
+        g_source_remove(self->id),
+            self->id = 0;
+    }
+}
+
+void
+later_execute(later_t *self)
+{
+    later_cancel(self);
+    log_debug("later(%s) execute", self->label);
+    self->func(self->aptr);
+}
+
+static gboolean
+later_trigger_cb(gpointer aptr)
+{
+    later_t *self = aptr;
+    log_debug("later(%s) triggered", self->label);
+    self->id = 0;
+    later_execute(self);
+    return G_SOURCE_REMOVE;
+}

--- a/daemon/later.h
+++ b/daemon/later.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  LATER_H_
+# define LATER_H_
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct later_t later_t;
+typedef void (*later_func_t)(gpointer aptr);
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+later_t *later_create   (const char *label, gint priority, guint delay, later_func_t func, gpointer aptr);
+void     later_delete   (later_t *self);
+void     later_delete_at(later_t **pself);
+void     later_schedule (later_t *self);
+void     later_cancel   (later_t *self);
+void     later_execute  (later_t *self);
+
+G_END_DECLS
+
+#endif /* LATER_H_ */

--- a/daemon/logging.c
+++ b/daemon/logging.c
@@ -1,0 +1,149 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "logging.h"
+
+#include "util.h"
+
+#include <stdio.h>
+#include <errno.h>
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * LOG
+ * ------------------------------------------------------------------------- */
+
+void               log_set_target     (log_target_t target);
+static int         log_normalize_level(int lev);
+static const char *log_tag            (int lev);
+int                log_get_level      (void);
+void               log_set_level      (int lev);
+bool               log_p              (int lev);
+void               log_emit_real      (const char *file, int line, const char *func, int lev, const char *fmt, ...) __attribute__((format(printf, 5, 6)));
+
+/* ========================================================================= *
+ * LOG
+ * ========================================================================= */
+
+static int log_level = LOG_WARNING;
+
+static log_target_t log_target = LOG_TO_STDERR;
+
+void
+log_set_target(log_target_t target)
+{
+    log_target = target;
+}
+
+static int
+log_normalize_level(int lev)
+{
+    return (lev < LOG_CRIT) ? LOG_CRIT : (lev > LOG_TRACE) ? LOG_TRACE : lev;
+}
+
+static const char *
+log_tag(int lev)
+{
+    static const char * const tag[] = {
+        [LOG_EMERG]   = "X: ",
+        [LOG_ALERT]   = "A: ",
+        [LOG_CRIT]    = "C: ",
+        [LOG_ERR]     = "E: ",
+        [LOG_WARNING] = "W: ",
+        [LOG_NOTICE]  = "N: ",
+        [LOG_INFO]    = "I: ",
+        [LOG_DEBUG]   = "D: ",
+        [LOG_TRACE]   = "T: ",
+    };
+    return tag[lev];
+}
+
+int
+log_get_level(void)
+{
+    return log_level;
+}
+
+void
+log_set_level(int lev)
+{
+    log_level = log_normalize_level(lev);
+}
+
+bool
+log_p(int lev)
+{
+    return log_normalize_level(lev) <= log_level;
+}
+
+void
+log_emit_real(const char *file, int line, const char *func, int lev, const char *fmt, ...)
+{
+    (void)file;
+    (void)line;
+    (void)func;
+
+    lev = log_normalize_level(lev);
+    if( lev <= log_level ) {
+        int saved = errno;
+
+        va_list va;
+        va_start(va, fmt);
+        if( log_target == LOG_TO_SYSLOG ) {
+            vsyslog(lev, fmt, va);
+        }
+        else {
+            char *msg = 0;
+            if( vasprintf(&msg, fmt, va) < 0 )
+                msg = 0;
+
+#if LOGGING_SHOW_FUNCTION
+            fprintf(stderr, "%s:%d: %s(): %s%s\n",
+                    file, line, func, log_tag(lev), msg ? strip(msg) : fmt);
+#else
+            fprintf(stderr, "%s%s\n", log_tag(lev), msg ? strip(msg) : fmt);
+#endif
+            fflush(stderr);
+            free(msg);
+        }
+        va_end(va);
+
+        errno = saved;
+    }
+}

--- a/daemon/logging.h
+++ b/daemon/logging.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef LOGGING_H_
+# define LOGGING_H_
+
+# include <stdbool.h>
+# include <syslog.h>
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Macros
+ * ========================================================================= */
+
+# ifndef LOG_DEBUG
+#  error foobar
+# else
+# define LOG_TRACE 8
+#endif
+
+# if 01
+#  define LOGGING_SHOW_FUNCTION 1
+#  define LOGGING_LEVEL LOG_DEBUG
+# else
+#  define LOGGING_SHOW_FUNCTION 0
+#  define LOGGING_LEVEL LOG_INFO
+# endif
+
+# define log_emit(LEV, FMT, ARGS...) do {\
+    if( log_p(LEV) ) {\
+        log_emit_real(__FILE__, __LINE__, __func__, LEV, FMT, ##ARGS);\
+    }\
+} while(0)
+
+# define log_crit(    FMT, ARGS...) log_emit(LOG_CRIT,    FMT, ##ARGS)
+# define log_err(     FMT, ARGS...) log_emit(LOG_ERR,     FMT, ##ARGS)
+# define log_warning( FMT, ARGS...) log_emit(LOG_WARNING, FMT, ##ARGS)
+
+# if LOGGING_LEVEL >= LOG_NOTICE
+#  define log_notice( FMT, ARGS...) log_emit(LOG_NOTICE,  FMT, ##ARGS)
+# else
+#  define log_notice( FMT, ARGS...) do{}while(0)
+# endif
+
+# if LOGGING_LEVEL >= LOG_INFO
+#  define log_info(   FMT, ARGS...) log_emit(LOG_INFO,    FMT, ##ARGS)
+# else
+#  define log_info(   FMT, ARGS...) do{}while(0)
+# endif
+
+# if LOGGING_LEVEL >= LOG_DEBUG
+#  define log_debug(  FMT, ARGS...) log_emit(LOG_DEBUG,   FMT, ##ARGS)
+# else
+#  define log_debug(  FMT, ARGS...) do{}while(0)
+# endif
+
+# if LOGGING_LEVEL >= LOG_TRACE
+#  define log_trace(  FMT, ARGS...) log_emit(LOG_TRACE,   FMT, ##ARGS)
+# else
+#  define log_trace(  FMT, ARGS...) do{}while(0)
+# endif
+
+# if 01
+#  define HERE do{}while(0)
+# elif LOGGING_SHOW_FUNCTION
+#  define HERE log_debug("...")
+# else
+#  define HERE log_debug("%s:%d: %s(): ...", __FILE__, __LINE__, __func__)
+# endif
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef enum {
+    LOG_TO_STDERR,
+    LOG_TO_SYSLOG,
+} log_target_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * LOG
+ * ------------------------------------------------------------------------- */
+
+void log_set_target(log_target_t target);
+int  log_get_level (void);
+void log_set_level (int lev);
+bool log_p         (int lev);
+void log_emit_real (const char *file, int line, const char *func, int lev, const char *fmt, ...) __attribute__((format(printf, 5, 6)));
+
+G_END_DECLS
+
+#endif /* LOGGING_H_ */

--- a/daemon/mainloop.c
+++ b/daemon/mainloop.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "mainloop.h"
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+int  app_run (void);
+void app_exit(int exit_code);
+void app_quit(void);
+
+/* ========================================================================= *
+ * APP
+ * ========================================================================= */
+
+static GMainLoop *app_mainloop = NULL;
+static int        app_exitcode = EXIT_FAILURE;
+
+int
+app_run(void)
+{
+    app_exitcode = EXIT_FAILURE;
+    if( (app_mainloop = g_main_loop_new(NULL, FALSE)) ) {
+        g_main_loop_run(app_mainloop);
+        g_main_loop_unref(app_mainloop),
+            app_mainloop = NULL;
+    }
+    return app_exitcode;
+}
+
+void
+app_exit(int exit_code)
+{
+    if( !app_mainloop )
+        exit(EXIT_FAILURE);
+
+    app_exitcode = exit_code;
+    g_main_loop_quit(app_mainloop);
+}
+
+void
+app_quit(void)
+{
+    app_exit(EXIT_SUCCESS);
+}

--- a/daemon/mainloop.h
+++ b/daemon/mainloop.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  MAINLOOP_H_
+# define MAINLOOP_H_
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+int  app_run (void);
+void app_exit(int exit_code);
+void app_quit(void);
+
+G_END_DECLS
+
+#endif /* MAINLOOP_H_ */

--- a/daemon/permissions.c
+++ b/daemon/permissions.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "permissions.h"
+
+#include "logging.h"
+#include "control.h"
+#include "stringset.h"
+#include "util.h"
+
+#include <glob.h>
+#include <fnmatch.h>
+
+#include <gio/gio.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+#define PERMISSIONS_RESCAN_DELAY            1000 // [ms]
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+static void    permissions_ctor     (permissions_t *self, control_t *control);
+static void    permissions_dtor     (permissions_t *self);
+permissions_t *permissions_create   (control_t *control);
+void           permissions_delete   (permissions_t *self);
+void           permissions_delete_at(permissions_t **pself);
+void           permissions_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static control_t *permissions_control(const permissions_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_AVAILABLE
+ * ------------------------------------------------------------------------- */
+
+const stringset_t *permissions_available(permissions_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void permissions_notify_changed(permissions_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_MONITOR
+ * ------------------------------------------------------------------------- */
+
+static void permissions_start_monitor(permissions_t *self);
+static void permissions_stop_monitor (permissions_t *self);
+static bool permissions_monitor_p    (const gchar *path);
+static void permissions_monitor_cb   (GFileMonitor *mon, GFile *file1, GFile *file2, GFileMonitorEvent event, gpointer aptr);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_SCAN
+ * ------------------------------------------------------------------------- */
+
+static bool     permissions_scan_now     (permissions_t *self);
+static gboolean permissions_rescan_cb    (gpointer aptr);
+static void     permissions_rescan_later (permissions_t *self);
+static bool     permissions_cancel_rescan(permissions_t *self);
+
+/* ========================================================================= *
+ * PERMISSIONS
+ * ========================================================================= */
+
+struct permissions_t
+{
+    bool                   prm_initialized;
+    control_t             *prm_control;
+    stringset_t           *prm_current;
+    guint                  prm_rescan_id;
+    GFileMonitor          *prm_monitor_obj;
+};
+
+static void
+permissions_ctor(permissions_t *self, control_t *control)
+{
+    log_info("permissions() create");
+
+    self->prm_initialized = false;
+    self->prm_control     = control;
+    self->prm_current     = stringset_create();
+    self->prm_rescan_id   = 0;
+    self->prm_monitor_obj = NULL;
+
+    /* Fetch initial state */
+    permissions_start_monitor(self);
+    permissions_scan_now(self);
+
+    /* Enable notifications */
+    self->prm_initialized = true;
+}
+
+static  void
+permissions_dtor(permissions_t *self)
+{
+    log_info("permissions() delete");
+
+    /* Detach notification hooks */
+    self->prm_initialized = false;
+
+    permissions_stop_monitor(self);
+    permissions_cancel_rescan(self);
+    stringset_delete_at(&self->prm_current);
+}
+
+permissions_t *
+permissions_create(control_t *control)
+{
+    permissions_t *self = g_malloc0(sizeof *self);
+    permissions_ctor(self, control);
+    return self;
+}
+
+void
+permissions_delete(permissions_t *self)
+{
+    if( self ) {
+        permissions_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+permissions_delete_at(permissions_t **pself)
+{
+    permissions_delete(*pself), *pself = NULL;
+}
+
+void
+permissions_delete_cb(void *self)
+{
+    permissions_delete(self);
+}
+
+/* ========================================================================= *
+ * PERMISSIONS_ATTRIBUTES
+ * ========================================================================= */
+
+static control_t *
+permissions_control(const permissions_t *self)
+{
+    return self->prm_control;
+}
+
+/* ========================================================================= *
+ * PERMISSIONS_AVAILABLE
+ * ========================================================================= */
+
+const stringset_t *
+permissions_available(permissions_t *self)
+{
+    if( permissions_cancel_rescan(self) )
+        permissions_scan_now(self);
+
+    return self->prm_current;
+}
+
+/* ========================================================================= *
+ * PERMISSIONS_NOTIFY
+ * ========================================================================= */
+
+static void
+permissions_notify_changed(permissions_t *self)
+{
+    if( self->prm_initialized ) {
+        log_info("PERMISSIONS NOTIFY");
+        control_on_permissions_change(permissions_control(self));
+    }
+}
+
+/* ========================================================================= *
+ * PERMISSIONS_MONITOR
+ * ========================================================================= */
+
+static void
+permissions_start_monitor(permissions_t *self)
+{
+    permissions_stop_monitor(self);
+
+    GFileMonitorFlags flags = G_FILE_MONITOR_WATCH_MOVES;
+    GFile *file = g_file_new_for_path(PERMISSIONS_DIRECTORY);
+    if( file ) {
+        if( (self->prm_monitor_obj = g_file_monitor_directory(file, flags, 0, 0)) ) {
+            g_signal_connect(self->prm_monitor_obj, "changed",
+                             G_CALLBACK(permissions_monitor_cb), self);
+            log_info("PERMISSIONS MONITOR: started");
+        }
+        g_object_unref(file);
+    }
+}
+
+static void
+permissions_stop_monitor(permissions_t *self)
+{
+    if( self->prm_monitor_obj ) {
+        log_info("PERMISSIONS MONITOR: stopped");
+        g_object_unref(self->prm_monitor_obj),
+            self->prm_monitor_obj = NULL;
+    }
+}
+
+static bool
+permissions_monitor_p(const gchar *path)
+{
+    path = path_basename(path);
+    return path && fnmatch(PERMISSIONS_PATTERN, path, FNM_PATHNAME) == 0;
+}
+
+static void
+permissions_monitor_cb(GFileMonitor      *mon,
+                       GFile             *file1,
+                       GFile             *file2,
+                       GFileMonitorEvent  event,
+                       gpointer           aptr)
+{
+    permissions_t *self = aptr;
+
+    const char *path1 = file1 ? g_file_peek_path(file1) : NULL;
+    const char *path2 = file2 ? g_file_peek_path(file2) : NULL;
+    bool trigger = (permissions_monitor_p(path1) ||
+                    permissions_monitor_p(path2));
+
+    if( trigger ) {
+        log_info("PERMISSIONS MONITOR: trigger @ %s %s", path1, path2);
+        permissions_rescan_later(self);
+    }
+}
+
+/* ========================================================================= *
+ * PERMISSIONS_SCAN
+ * ========================================================================= */
+
+static bool
+permissions_scan_now(permissions_t *self)
+{
+    permissions_cancel_rescan(self);
+    log_info("PERMISSIONS RESCAN: executing");
+
+    bool changed = false;
+
+    stringset_t *scanned = stringset_create();
+    glob_t       gl    = {};
+
+    if( glob(PERMISSIONS_DIRECTORY "/" PERMISSIONS_PATTERN, 0, 0, &gl) != 0 ) {
+        /* Keep current data */
+        goto EXIT;
+    }
+
+    /* 'Privileged' exists even if there is no
+     * matching permission file present.
+     */
+    stringset_add_item(scanned, PERMISSION_PRIVILEGED);
+
+    for( int i = 0; i < gl.gl_pathc; ++i ) {
+        gchar *name = path_to_permission_name(gl.gl_pathv[i]);
+        stringset_add_item(scanned, name);
+        g_free(name);
+    }
+
+    /* 'Base' does not play role in permission management
+     * even if a matching file for it would be present.
+     */
+    stringset_remove_item(scanned, PERMISSION_BASE);
+
+    stringset_t *addset = stringset_filter_out(scanned, self->prm_current);
+    stringset_t *remset = stringset_filter_out(self->prm_current, scanned);
+
+    if( !stringset_empty(addset) ) {
+        gchar *addstr = stringset_to_string(addset);
+        if( addstr && *addstr )
+            log_notice("PERMISSIONS RESCAN: added: %s", addstr);
+        g_free(addstr);
+        changed = true;
+    }
+
+    if( !stringset_empty(remset) ) {
+        gchar *remstr = stringset_to_string(remset);
+        if( remstr && *remstr )
+            log_notice("PERMISSIONS RESCAN: removed: %s", remstr);
+        g_free(remstr);
+        changed = true;
+    }
+
+    stringset_delete(addset);
+    stringset_delete(remset);
+
+    if( changed )
+        stringset_swap(self->prm_current, scanned);
+
+EXIT:
+    stringset_delete(scanned);
+    globfree(&gl);
+    return changed;
+}
+
+static gboolean
+permissions_rescan_cb(gpointer aptr)
+{
+    permissions_t *self = aptr;
+
+    self->prm_rescan_id = 0;
+
+    log_info("PERMISSIONS RESCAN: triggered");
+    if( permissions_scan_now(self) )
+        permissions_notify_changed(self);
+
+    return G_SOURCE_REMOVE;
+}
+
+static void
+permissions_rescan_later(permissions_t *self)
+{
+    if( !self->prm_rescan_id )
+        log_info("PERMISSIONS RESCAN: scheduled");
+    else
+        g_source_remove(self->prm_rescan_id);
+    self->prm_rescan_id = g_timeout_add(PERMISSIONS_RESCAN_DELAY,
+                                        permissions_rescan_cb, self);
+}
+
+static bool
+permissions_cancel_rescan(permissions_t *self)
+{
+    bool canceled = false;
+    if( self->prm_rescan_id ) {
+        log_info("PERMISSIONS RESCAN: canceled");
+        g_source_remove(self->prm_rescan_id),
+            self->prm_rescan_id = 0;
+        canceled = true;
+    }
+    return canceled;
+}

--- a/daemon/permissions.h
+++ b/daemon/permissions.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  PERMISSIONS_H_
+# define PERMISSIONS_H_
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Constants
+ * ========================================================================= */
+
+# define PERMISSION_BASE       "Base"
+# define PERMISSION_PRIVILEGED "Privileged"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct control_t     control_t;
+typedef struct config_t      config_t;
+typedef struct stringset_t   stringset_t;
+typedef struct permissions_t permissions_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+permissions_t *permissions_create   (control_t *control);
+void           permissions_delete   (permissions_t *self);
+void           permissions_delete_at(permissions_t **pself);
+void           permissions_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * PERMISSIONS_AVAILABLE
+ * ------------------------------------------------------------------------- */
+
+const stringset_t *permissions_available(permissions_t *self);
+
+G_END_DECLS
+
+#endif /* PERMISSIONS_H_ */

--- a/daemon/prompter.c
+++ b/daemon/prompter.c
@@ -1,0 +1,917 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "prompter.h"
+
+#include "control.h"
+#include "service.h"
+#include "session.h"
+#include "stringset.h"
+#include "appinfo.h"
+#include "settings.h"
+#include "util.h"
+#include "logging.h"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct service_t service_t;
+typedef struct appinfo_t appinfo_t;
+
+typedef enum prompter_state_t {
+    PROMPTER_STATE_UNDEFINED,
+    PROMPTER_STATE_IDLE,
+    PROMPTER_STATE_CONNECT,
+    PROMPTER_STATE_PROMPT,
+    PROMPTER_STATE_DISCONNECT,
+    PROMPTER_STATE_CONNECTION_FAILURE,
+    PROMPTER_STATE_PROMPTING_FAILURE,
+    PROMPTER_STATE_FINAL
+} prompter_state_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * CHANGE
+ * ------------------------------------------------------------------------- */
+
+static bool change_timer(guint *pmember, guint value);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_STATE
+ * ------------------------------------------------------------------------- */
+
+static const char *prompter_state_repr(prompter_state_t state);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER
+ * ------------------------------------------------------------------------- */
+
+static void  prompter_ctor     (prompter_t *self, service_t *service);
+static void  prompter_dtor     (prompter_t *self);
+prompter_t  *prompter_create   (service_t *service);
+void         prompter_delete   (prompter_t *self);
+void         prompter_delete_at(prompter_t **pself);
+void         prompter_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static service_t     *prompter_service     (const prompter_t *self);
+static control_t     *prompter_control     (const prompter_t *self);
+static appsettings_t *prompter_appsettings (const prompter_t *self, uid_t uid, const char *app);
+static uid_t          prompter_current_user(const prompter_t *self);
+static gchar         *prompter_bus_address (const prompter_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_STM
+ * ------------------------------------------------------------------------- */
+
+static prompter_state_t prompter_get_state       (const prompter_t *self);
+static void             prompter_enter_state     (prompter_t *self);
+static void             prompter_leave_state     (prompter_t *self);
+static void             prompter_eval_state_now  (prompter_t *self);
+static void             prompter_eval_state_later(prompter_t *self);
+static gboolean         prompter_eval_state_cb   (gpointer aptr);
+static bool             prompter_state_transfer_p(prompter_state_t prev, prompter_state_t next);
+static void             prompter_set_state       (prompter_t *self, prompter_state_t state);
+static bool             prompter_step_state      (prompter_t *self);
+static void             prompter_exec_state      (prompter_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_TIMER
+ * ------------------------------------------------------------------------- */
+
+static bool     prompter_timer_running(const prompter_t *self);
+static void     prompter_start_timer  (prompter_t *self, int ms);
+static void     prompter_stop_timer   (prompter_t *self);
+static gboolean prompter_timer_cb     (gpointer aptr);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_INVOCATION
+ * ------------------------------------------------------------------------- */
+
+static GDBusMethodInvocation *prompter_current_invocation  (prompter_t *self);
+static void                   prompter_finish_invocation   (prompter_t *self);
+static void                   prompter_fail_invocation     (prompter_t *self);
+static void                   prompter_reply_invocation    (prompter_t *self);
+static GDBusMethodInvocation *prompter_next_invocation     (prompter_t *self);
+static void                   prompter_prompt_invocation_cb(GObject *obj, GAsyncResult *res, gpointer aptr);
+static GVariant              *prompter_invocation_args     (const prompter_t *self, appinfo_t *appinfo);
+static bool                   prompter_prompt_invocation   (prompter_t *self);
+void                          prompter_handle_invocation   (prompter_t *self, GDBusMethodInvocation *invocation);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_RETURN
+ * ------------------------------------------------------------------------- */
+
+static void prompter_return_value(GDBusMethodInvocation *invocation, GVariant *val);
+static void prompter_return_error(GDBusMethodInvocation *invocation, int code, const char *fmt, ...) __attribute__((format(printf, 3, 4)));
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_QUEUE
+ * ------------------------------------------------------------------------- */
+
+static void                   prompter_enqueue    (prompter_t *self, GDBusMethodInvocation *invocation);
+static guint                  prompter_queued     (prompter_t *self);
+static GDBusMethodInvocation *prompter_dequeue    (prompter_t *self);
+static void                   prompter_dequeue_all(prompter_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_CONNECTION
+ * ------------------------------------------------------------------------- */
+
+static GDBusConnection *prompter_connection  (const prompter_t *self);
+static bool             prompter_is_connected(const prompter_t *self);
+static bool             prompter_connect     (prompter_t *self);
+static void             prompter_disconnect  (prompter_t *self);
+
+/* ========================================================================= *
+ * UTILITY
+ * ========================================================================= */
+
+static bool
+change_timer(guint *pmember, guint value)
+{
+    bool changed = false;
+    if( *pmember != value ) {
+        g_source_remove(*pmember);
+        *pmember = value;
+        changed = true;
+    }
+    return changed;
+}
+
+/* ========================================================================= *
+ * PROMPTER_STATE
+ * ========================================================================= */
+
+static const char *
+prompter_state_repr(prompter_state_t state)
+{
+    static const char * const lut[] =  {
+        [PROMPTER_STATE_UNDEFINED]          = "UNDEFINED",
+        [PROMPTER_STATE_IDLE]               = "IDLE",
+        [PROMPTER_STATE_CONNECT]            = "CONNECT",
+        [PROMPTER_STATE_PROMPT]             = "PROMPT",
+        [PROMPTER_STATE_DISCONNECT]         = "DISCONNECT",
+        [PROMPTER_STATE_CONNECTION_FAILURE] = "CONNECTION_FAILURE",
+        [PROMPTER_STATE_PROMPTING_FAILURE]  = "PROMPTING_FAILURE",
+        [PROMPTER_STATE_FINAL]              = "FINAL",
+    };
+    return lut[state];
+}
+
+/* ========================================================================= *
+ * PROMPTER
+ * ========================================================================= */
+
+struct prompter_t
+{
+    service_t             *prm_service;
+    prompter_state_t       prm_state;
+    guint                  prm_timer_id;
+    guint                  prm_later_id;
+    GQueue                *prm_queue;           // GDBusMethodInvocation *
+    GDBusConnection       *prm_connection;
+    GDBusMethodInvocation *prm_invocation;
+};
+
+static void
+prompter_ctor(prompter_t *self, service_t *service)
+{
+    log_info("prompter() create");
+    self->prm_service    = service;
+    self->prm_state      = PROMPTER_STATE_UNDEFINED;
+    self->prm_timer_id   = 0;
+    self->prm_later_id   = 0;
+    self->prm_queue      = g_queue_new();
+    self->prm_connection = NULL;
+    self->prm_invocation = NULL;
+    prompter_set_state(self, PROMPTER_STATE_IDLE);
+}
+
+static void
+prompter_dtor(prompter_t *self)
+{
+    log_info("prompter() delete");
+
+    /* Transition to FINAL state should flush the
+     * queue, stop transition timers, etc */
+    prompter_set_state(self, PROMPTER_STATE_FINAL);
+
+    change_timer(&self->prm_later_id, 0);
+
+    g_queue_free(self->prm_queue),
+        self->prm_queue = NULL;
+
+    self->prm_service = NULL;
+}
+
+prompter_t *
+prompter_create(service_t *service)
+{
+    prompter_t *self = g_malloc0(sizeof *self);
+    prompter_ctor(self, service);
+    return self;
+}
+
+void
+prompter_delete(prompter_t *self)
+{
+    if( self ) {
+        prompter_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+prompter_delete_at(prompter_t **pself)
+{
+    prompter_delete(*pself), *pself = NULL;
+}
+
+void
+prompter_delete_cb(void *self)
+{
+    prompter_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static service_t *
+prompter_service(const prompter_t *self)
+{
+    return self->prm_service;
+}
+
+static control_t *
+prompter_control(const prompter_t *self)
+{
+    return service_control(prompter_service(self));
+}
+
+static appsettings_t *
+prompter_appsettings(const prompter_t *self, uid_t uid, const char *app)
+{
+    return control_appsettings(prompter_control(self), uid, app);
+}
+
+static uid_t
+prompter_current_user(const prompter_t *self)
+{
+    // FIXME: this should be cached internally for error
+    //        error reply handling on session change...
+    return control_current_user(prompter_control(self));
+}
+
+static gchar *
+prompter_bus_address(const prompter_t *self)
+{
+    gchar *addr = NULL;
+    uid_t  uid  = control_current_user(prompter_control(self));
+    if( uid != SESSION_UID_UNDEFINED )
+        addr = g_strdup_printf("unix:path=/run/user/%lld/dbus/user_bus_socket",
+                               (long long)uid);
+    return addr;
+}
+
+#ifdef DEAD_CODE
+static applications_t *
+prompter_applications(const prompter_t *self)
+{
+    return control_applications(prompter_control(self));
+}
+#endif
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_STM
+ * ------------------------------------------------------------------------- */
+
+static prompter_state_t
+prompter_get_state(const prompter_t *self)
+{
+    return self->prm_state;
+}
+
+static void
+prompter_enter_state(prompter_t *self)
+{
+    switch( prompter_get_state(self) ) {
+    case PROMPTER_STATE_UNDEFINED:
+        abort();
+        break;
+
+    case PROMPTER_STATE_IDLE:
+        break;
+
+    case PROMPTER_STATE_CONNECT:
+        // FIXME: this should be done asynchronously
+        if( !prompter_connect(self) )
+            prompter_set_state(self, PROMPTER_STATE_CONNECTION_FAILURE);
+        break;
+
+    case PROMPTER_STATE_PROMPT:
+        break;
+
+    case PROMPTER_STATE_DISCONNECT:
+        prompter_disconnect(self);
+        break;
+
+    case PROMPTER_STATE_CONNECTION_FAILURE:
+        /* Rate limit connection attempts */
+        prompter_start_timer(self, 5000);
+        break;
+
+    case PROMPTER_STATE_PROMPTING_FAILURE:
+        /* Rate limit prompting attempts */
+        prompter_start_timer(self, 1000);
+        break;
+
+    case PROMPTER_STATE_FINAL:
+        /* Drop user session connection */
+        prompter_disconnect(self);
+        /* Fail all queued requests */
+        prompter_dequeue_all(self);
+        /* Fail pending queued request */
+        prompter_fail_invocation(self);
+        break;
+    }
+}
+
+static void
+prompter_leave_state(prompter_t *self)
+{
+    switch( prompter_get_state(self) ) {
+    case PROMPTER_STATE_UNDEFINED:
+        break;
+
+    case PROMPTER_STATE_IDLE:
+        break;
+
+    case PROMPTER_STATE_CONNECT:
+        break;
+
+    case PROMPTER_STATE_PROMPT:
+        prompter_fail_invocation(self);
+        break;
+
+    case PROMPTER_STATE_DISCONNECT:
+        break;
+
+    case PROMPTER_STATE_CONNECTION_FAILURE:
+        prompter_stop_timer(self);
+        break;
+
+    case PROMPTER_STATE_PROMPTING_FAILURE:
+        prompter_stop_timer(self);
+        break;
+
+    case PROMPTER_STATE_FINAL:
+        abort();
+        break;
+    }
+}
+
+static void
+prompter_eval_state_now(prompter_t *self)
+{
+    change_timer(&self->prm_later_id, 0);
+
+    switch( prompter_get_state(self) ) {
+    case PROMPTER_STATE_UNDEFINED:
+        break;
+
+    case PROMPTER_STATE_IDLE:
+        if( prompter_queued(self) )
+            prompter_set_state(self, PROMPTER_STATE_CONNECT);
+        break;
+
+    case PROMPTER_STATE_CONNECT:
+        if( prompter_is_connected(self) )
+            prompter_set_state(self, PROMPTER_STATE_PROMPT);
+        break;
+
+    case PROMPTER_STATE_PROMPT:
+        if( prompter_current_invocation(self) ) {
+            /* We have a pending call */
+        }
+        else if( !prompter_next_invocation(self) ) {
+            prompter_set_state(self, PROMPTER_STATE_DISCONNECT);
+        }
+        else if( !prompter_prompt_invocation(self) ) {
+            prompter_fail_invocation(self);
+        }
+        break;
+
+    case PROMPTER_STATE_DISCONNECT:
+        if( !prompter_is_connected(self) )
+            prompter_set_state(self, PROMPTER_STATE_IDLE);
+        break;
+
+    case PROMPTER_STATE_CONNECTION_FAILURE:
+        if( !prompter_timer_running(self) )
+            prompter_set_state(self, PROMPTER_STATE_IDLE);
+        break;
+
+    case PROMPTER_STATE_PROMPTING_FAILURE:
+        if( !prompter_timer_running(self) )
+            prompter_set_state(self, PROMPTER_STATE_DISCONNECT);
+        break;
+
+    case PROMPTER_STATE_FINAL:
+        break;
+    }
+}
+
+static void
+prompter_eval_state_later(prompter_t *self)
+{
+    if( !self->prm_later_id )
+        self->prm_later_id = g_idle_add(prompter_eval_state_cb, self);
+}
+
+static gboolean
+prompter_eval_state_cb(gpointer aptr)
+{
+    prompter_t *self = aptr;
+    self->prm_later_id = 0;
+    prompter_eval_state_now(self);
+    return G_SOURCE_REMOVE;
+}
+
+static bool
+prompter_state_transfer_p(prompter_state_t prev, prompter_state_t next)
+{
+    if( prev == PROMPTER_STATE_FINAL )
+        return false;
+    if( next == PROMPTER_STATE_UNDEFINED )
+        return false;
+    return true;
+}
+
+static void
+prompter_set_state(prompter_t *self, prompter_state_t state)
+{
+    if( self->prm_state != state ) {
+        if( !prompter_state_transfer_p(self->prm_state, state) ) {
+            log_err("rejected transition: %s -> %s",
+                    prompter_state_repr(self->prm_state),
+                    prompter_state_repr(state));
+        }
+        else {
+            log_info("state transition: %s -> %s",
+                     prompter_state_repr(self->prm_state),
+                     prompter_state_repr(state));
+
+            prompter_leave_state(self);
+            self->prm_state = state;
+            prompter_enter_state(self);
+
+            prompter_eval_state_later(self);
+        }
+    }
+}
+
+static bool
+prompter_step_state(prompter_t *self)
+{
+    prompter_state_t state = prompter_get_state(self);
+    prompter_eval_state_now(self);
+    return prompter_get_state(self) != state;
+}
+
+static void
+prompter_exec_state(prompter_t *self)
+{
+    while( prompter_step_state(self) )
+        ;
+}
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_TIMER
+ * ------------------------------------------------------------------------- */
+
+static bool
+prompter_timer_running(const prompter_t *self)
+{
+    return self->prm_timer_id != 0;
+}
+
+static void
+prompter_start_timer(prompter_t *self, int ms)
+{
+    change_timer(&self->prm_timer_id,
+                 g_timeout_add(ms, prompter_timer_cb, self));
+}
+
+static void
+prompter_stop_timer(prompter_t *self)
+{
+    change_timer(&self->prm_timer_id, 0);
+}
+
+static gboolean
+prompter_timer_cb(gpointer aptr)
+{
+    prompter_t *self = aptr;
+    self->prm_timer_id = 0;
+    prompter_exec_state(self);
+    return G_SOURCE_REMOVE;
+}
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_INVOCATION
+ * ------------------------------------------------------------------------- */
+
+static GDBusMethodInvocation *
+prompter_current_invocation(prompter_t *self)
+{
+    return self->prm_invocation;
+}
+
+static void
+prompter_finish_invocation(prompter_t *self)
+{
+    GDBusMethodInvocation *invocation = self->prm_invocation;
+    if( invocation ) {
+        self->prm_invocation = NULL;
+
+        uid_t uid = prompter_current_user(self);
+
+        appsettings_t *appsettings = NULL;
+        GVariant *parameters =
+            g_dbus_method_invocation_get_parameters(invocation);
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(&s)", &app);
+        if( !app ) {
+            prompter_return_error(invocation, G_DBUS_ERROR_INVALID_ARGS,
+                                  SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else if( !(appsettings = prompter_appsettings(self, uid, app)) ) {
+            prompter_return_error(invocation, G_DBUS_ERROR_INVALID_ARGS,
+                                  SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else {
+            app_allowed_t allowed = appsettings_get_allowed(appsettings);
+            if( allowed == APP_ALLOWED_NEVER ) {
+                prompter_return_error(invocation, G_DBUS_ERROR_AUTH_FAILED,
+                                      SERVICE_MESSAGE_DENIED_PERMANENTLY);
+            }
+            else if( allowed == APP_ALLOWED_ALWAYS ) {
+                const stringset_t *granted =
+                    appsettings_get_granted(appsettings);
+                gchar **vector = stringset_to_strv(granted);
+                GVariant *variant =
+                    g_variant_new_strv((const gchar * const *)vector, -1);
+                prompter_return_value(invocation, variant);
+                g_strfreev(vector);
+            }
+            else {
+                prompter_return_error(invocation, G_DBUS_ERROR_AUTH_FAILED,
+                                      SERVICE_MESSAGE_NOT_ALLOWED);
+            }
+        }
+
+        prompter_eval_state_later(self);
+    }
+}
+
+static void
+prompter_fail_invocation(prompter_t *self)
+{
+    if( self->prm_invocation ) {
+        /* Return existing permissions */
+        prompter_finish_invocation(self);
+    }
+}
+
+static void
+prompter_reply_invocation(prompter_t *self)
+{
+    if( self->prm_invocation ) {
+        GVariant *parameters =
+            g_dbus_method_invocation_get_parameters(self->prm_invocation);
+        if( parameters ) {
+            uid_t        uid = prompter_current_user(self);
+            const gchar *app = NULL;
+            g_variant_get(parameters, "(&s)", &app);
+            if( app ) {
+                appsettings_t *appsettings =
+                    prompter_appsettings(self, uid, app);
+                if( appsettings ) {
+                    /* Allowing sets also granted before returning */
+                    appsettings_set_allowed(appsettings, APP_ALLOWED_ALWAYS);
+                }
+            }
+        }
+
+        /* Return the possibly just granted permissions */
+        prompter_finish_invocation(self);
+    }
+}
+
+static GDBusMethodInvocation *
+prompter_next_invocation(prompter_t *self)
+{
+    for( ;; ) {
+        prompter_fail_invocation(self);
+
+        if( !(self->prm_invocation = prompter_dequeue(self)) )
+            break;
+
+        log_debug("consider %p", self->prm_invocation);
+
+        GVariant *parameters =
+            g_dbus_method_invocation_get_parameters(self->prm_invocation);
+        if( !parameters ) {
+            log_debug("no parameters");
+            continue;
+        }
+
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(&s)", &app);
+        if( !app ) {
+            log_debug("no app");
+            continue;
+        }
+
+        uid_t uid = prompter_current_user(self);
+        appsettings_t *appsettings = prompter_appsettings(self, uid, app);
+        if( !appsettings ) {
+            log_debug("no appsettings");
+            continue;
+        }
+
+        app_allowed_t allowed = appsettings_get_allowed(appsettings);
+        if( allowed == APP_ALLOWED_UNSET ) {
+            log_debug("prompting ...");
+            break;
+        }
+        if( allowed == APP_ALLOWED_ALWAYS ) {
+            log_debug("already allowed");
+            prompter_reply_invocation(self);
+        }
+        else {
+            log_debug("already denied");
+        }
+    }
+
+    log_debug("process %p", self->prm_invocation);
+    return self->prm_invocation;
+}
+
+static void
+prompter_prompt_invocation_cb(GObject *obj, GAsyncResult *res, gpointer aptr)
+{
+    GDBusConnection *con  = G_DBUS_CONNECTION(obj);
+    prompter_t      *self = aptr;
+    GError          *err  = NULL;
+    GVariant        *rsp  = NULL;
+
+    if( !(rsp = g_dbus_connection_call_finish(con, res, &err)) ) {
+        if( err )
+            log_err("error reply: domain=%u code=%d message='%s'",
+                    (unsigned)err->domain, err->code, err->message);
+        else
+            log_err("null reply");
+        prompter_fail_invocation(self);
+    }
+    else {
+        prompter_reply_invocation(self);
+    }
+
+    g_clear_error(&err);
+}
+
+static GVariant *
+prompter_invocation_args(const prompter_t *self, appinfo_t *appinfo)
+{
+    GVariantBuilder builder;
+    g_variant_builder_init(&builder, G_VARIANT_TYPE("a{sas}"));
+
+    const stringset_t *permissions = appinfo_get_permissions(appinfo);
+    stringset_t *filtered = service_filter_permissions(prompter_service(self),
+                                                       permissions);
+    gchar **vector = stringset_to_strv(filtered);
+    for( guint i = 0; vector[i]; ++i ) {
+        gchar *perm = vector[i];
+        vector[i] = path_from_permission_name(perm);
+        g_free(perm);
+    }
+    g_variant_builder_add(&builder, "{s^as}", "required", vector);
+    g_strfreev(vector);
+
+    gchar *desktop = path_from_desktop_name(appinfo_id(appinfo));
+    GVariant *args = g_variant_new("(s@a{sas})", desktop,
+                                   g_variant_builder_end(&builder));
+    g_free(desktop);
+    stringset_delete(filtered);
+    return args;
+}
+
+static bool
+prompter_prompt_invocation(prompter_t *self)
+{
+    bool                ack     = false;
+    appinfo_t          *appinfo = NULL;
+    const gchar        *app     = NULL;
+    GCancellable       *cancellable  = NULL; // <-- FIXME: make this cancellable
+
+    GVariant *parameters =
+        g_dbus_method_invocation_get_parameters(prompter_current_invocation(self));
+
+    g_variant_get(parameters, "(&s)", &app);
+    if( !app ) {
+        log_err("could not parse application parameter");
+        goto EXIT;
+    }
+
+    if( !(appinfo = control_appinfo(prompter_control(self), app)) ) {
+        log_err("unknown app: %s", app);
+        goto EXIT;
+    }
+
+    g_dbus_connection_call(prompter_connection(self),
+                           WINDOWPROMT_SERVICE,
+                           WINDOWPROMT_OBJECT,
+                           WINDOWPROMT_INTERFACE,
+                           WINDOWPROMT_METHOD_PROMPT,
+                           prompter_invocation_args(self, appinfo),
+                           NULL,
+                           G_DBUS_CALL_FLAGS_NONE,
+                           G_MAXINT,
+                           cancellable,
+                           prompter_prompt_invocation_cb,
+                           self);
+
+    ack = true;
+
+EXIT:
+    return ack;
+}
+
+void
+prompter_handle_invocation(prompter_t *self, GDBusMethodInvocation *invocation)
+{
+    prompter_enqueue(self, invocation);
+    prompter_eval_state_later(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_RETURN
+ * ------------------------------------------------------------------------- */
+
+static void
+prompter_return_value(GDBusMethodInvocation *invocation, GVariant *val)
+{
+    g_dbus_method_invocation_return_value(invocation,
+                                          val
+                                          ? g_variant_new_tuple(&val, 1)
+                                          : NULL);
+}
+
+static void __attribute__((format(printf, 3, 4)))
+prompter_return_error(GDBusMethodInvocation *invocation, int code,
+                      const char *fmt, ...)
+{
+    va_list va;
+    va_start(va, fmt);
+    g_dbus_method_invocation_return_error_valist(invocation, G_DBUS_ERROR,
+                                                 code, fmt, va);
+    va_end(va);
+}
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_QUEUE
+ * ------------------------------------------------------------------------- */
+
+static void
+prompter_enqueue(prompter_t *self, GDBusMethodInvocation *invocation)
+{
+    log_info("enqueue %p", invocation);
+    g_queue_push_tail(self->prm_queue, invocation);
+}
+
+static guint
+prompter_queued(prompter_t *self)
+{
+    return self->prm_queue->length;
+}
+
+static GDBusMethodInvocation *
+prompter_dequeue(prompter_t *self)
+{
+    GDBusMethodInvocation *invocation = g_queue_pop_head(self->prm_queue);
+    log_info("dequeue %p", invocation);
+    return invocation;
+}
+
+static void
+prompter_dequeue_all(prompter_t *self)
+{
+    for( GList *iter = self->prm_queue->head; iter; iter = iter->next ) {
+        GDBusMethodInvocation *invocation = iter->data;
+        iter->data = NULL;
+        prompter_return_error(invocation, G_DBUS_ERROR_AUTH_FAILED,
+                              "Dismissed");
+    }
+    g_queue_remove_all(self->prm_queue, NULL);
+}
+
+// FIXME: on session changed -> dequeue_all
+// FIXME: on app removed -> dequeue_app (rejected due to invalid app)
+// FIXME: on app changed -> dequeue_app (accepted/rejected based on settings)
+// FIXME: and cancel the pending call too when appropriate
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_CONNECTION
+ * ------------------------------------------------------------------------- */
+
+static GDBusConnection *
+prompter_connection(const prompter_t *self)
+{
+    return self->prm_connection;
+}
+
+static bool
+prompter_is_connected(const prompter_t *self)
+{
+    return prompter_connection(self) != 0;
+}
+
+static bool
+prompter_connect(prompter_t *self)
+{
+    gchar  *address = NULL;
+    GError *error   = NULL;
+
+    if( self->prm_connection )
+        goto EXIT;
+
+    if( !(address = prompter_bus_address(self)) )
+        goto EXIT;
+
+    GDBusConnectionFlags flags =
+        G_DBUS_CONNECTION_FLAGS_AUTHENTICATION_CLIENT |
+        G_DBUS_CONNECTION_FLAGS_MESSAGE_BUS_CONNECTION;
+
+    self->prm_connection =
+        g_dbus_connection_new_for_address_sync(address, flags,
+                                               NULL, NULL, &error);
+
+    if( error )
+        log_err("connecting to %s failed: %s", address, error->message);
+EXIT:
+    g_clear_error(&error);
+    g_free(address);
+    return self->prm_connection != NULL;
+}
+
+static void
+prompter_disconnect(prompter_t *self)
+{
+    if( self->prm_connection ) {
+        g_object_unref(self->prm_connection),
+            self->prm_connection = NULL;
+    }
+}

--- a/daemon/prompter.h
+++ b/daemon/prompter.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  PROMPTER_H_
+# define PROMPTER_H_
+
+# include <gio/gio.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct appinfo_t      appinfo_t;
+typedef struct service_t      service_t;
+typedef struct applications_t applications_t;
+typedef struct prompter_t prompter_t;
+typedef struct control_t      control_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER
+ * ------------------------------------------------------------------------- */
+
+prompter_t *prompter_create   (service_t *service);
+void        prompter_delete   (prompter_t *self);
+void        prompter_delete_at(prompter_t **pself);
+void        prompter_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * PROMPTER_INVOCATION
+ * ------------------------------------------------------------------------- */
+
+void prompter_handle_invocation(prompter_t *self, GDBusMethodInvocation *invocation);
+
+G_END_DECLS
+
+#endif /* PROMPTER_H_ */

--- a/daemon/sailjaild.c
+++ b/daemon/sailjaild.c
@@ -1,0 +1,184 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "config.h"
+#include "control.h"
+#include "mainloop.h"
+#include "logging.h"
+#include "util.h"
+
+#include <getopt.h>
+
+#include <glib/gstdio.h>
+
+#include <systemd/sd-daemon.h>
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SAILJAILD
+ * ------------------------------------------------------------------------- */
+
+static void sailjaild_filesystem_setup(void);
+static int  sailjaild_main            (int argc, char **argv);
+
+/* ------------------------------------------------------------------------- *
+ * MAIN
+ * ------------------------------------------------------------------------- */
+
+int main(int argc, char **argv);
+
+/* ========================================================================= *
+ * SAILJAILD
+ * ========================================================================= */
+
+static const struct option long_options[] = {
+    {"help",         no_argument,       NULL, 'h'},
+    {"verbose",      no_argument,       NULL, 'v'},
+    {"quiet",        no_argument,       NULL, 'q'},
+    {"version",      no_argument,       NULL, 'V'},
+    {"systemd",      no_argument,       NULL, 'S'},
+    {"force-stderr", no_argument,       NULL, 'T'},
+    {"force-syslog", no_argument,       NULL, 's'},
+    {0, 0, 0, 0}
+};
+static const char short_options[] = "hvqVSTs";
+
+static void
+sailjaild_filesystem_setup(void)
+{
+    /* Note: Settings are stored in encrypted home partition. As
+     *       home might not be available/mounted at rpm install time,
+     *       data directories must be created during runtime.
+     */
+
+    /* Create directories using standard mode bits */
+    if( !g_file_test(SETTINGS_DIRECTORY, G_FILE_TEST_IS_DIR) ) {
+        if( g_mkdir_with_parents(SETTINGS_DIRECTORY, 0755) == -1 ) {
+            log_err("%s: could not create directory: %m", SETTINGS_DIRECTORY);
+
+            /* Limp onwards instead of possibly breaking everything */
+            log_warning("permissions can't be stored persistently");
+        }
+    }
+
+    /* Make settings directory itself accessible by root only */
+    if( g_chmod(SETTINGS_DIRECTORY, 0750) == -1 ) {
+        log_err("%s: could not update permissions: %m",
+                SETTINGS_DIRECTORY);
+    }
+
+    /* Settings files must not be world readable.
+     * As sailjaild writes only to settings files,
+     * we can just set umask here to accomplish it.
+     */
+    umask(0027);
+}
+
+static int
+sailjaild_main(int argc, char **argv)
+{
+    int       exit_code = EXIT_FAILURE;
+    config_t  *config   = config_create();
+    control_t *control  = NULL;
+    bool       systemd  = false;
+
+    /* Handle options */
+    for( ;; ) {
+        int opt = getopt_long(argc, argv, short_options, long_options, 0);
+
+        if( opt == -1 )
+            break;
+
+        switch( opt ) {
+        case 'h':
+            printf("usage: TBD\n");
+            exit_code = EXIT_SUCCESS;
+            goto EXIT;
+        case 'v':
+            log_set_level(log_get_level() + 1);
+            break;
+        case 'q':
+            log_set_level(log_get_level() - 1);
+            break;
+        case 'T':
+            log_set_target(LOG_TO_STDERR);
+            break;
+        case 's':
+            log_set_target(LOG_TO_SYSLOG);
+            break;
+        case 'V':
+            printf("%s\n", VERSION);
+            exit_code = EXIT_SUCCESS;
+            goto EXIT;
+        case 'S':
+            systemd = true;
+            log_set_target(LOG_TO_SYSLOG);
+            break;
+        case '?':
+            fprintf(stderr, "(use --help for instructions)\n");
+            goto EXIT;
+        }
+    }
+
+    sailjaild_filesystem_setup();
+
+    control = control_create(config);
+
+    if( systemd )
+        sd_notify(0, "READY=1");
+
+    exit_code = app_run();
+
+EXIT:
+    control_delete_at(&control);
+    config_delete_at(&config);
+
+    log_debug("exit %d", exit_code);
+    return exit_code;
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int
+main(int argc, char **argv)
+{
+    return sailjaild_main(argc, argv);
+}

--- a/daemon/sailjaild.dot
+++ b/daemon/sailjaild.dot
@@ -1,0 +1,128 @@
+/* -*- mode: c -*- */
+digraph foo {
+  rankdir=LR;
+  node[shape=box];
+  node[style=filled]
+  node[fillcolor=wheat];
+  node[width=0.001];
+  node[height=0.001];
+  node[fontsize=8];
+
+  edge[fontsize=7];
+  edge[color=grey30];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * PROCESSES
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[fillcolor=yellow];
+  CONTROL;
+  SETTINGS;
+  USER_SETTINGS;
+  APP_SETTINGS;
+  CONFIG;
+  PROMPTER;
+  SERVICE;
+  USERS;
+  APPLICATIONS;
+  APPINFO;
+  PERMISSIONS;
+  SESSION;
+  WINDOW_PROMPT         [label=" Permission\l Dialog in\l SessionBus\l"]
+  ANY                   [label=" (any)\l"]
+  DBUS_CLIENT           [label=" D-Bus\l client in\l SystemBus\l"]
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * DATASTORES
+   * - - - - - - - - - - - - - - - - - - - */
+
+  node[fillcolor=wheat];
+  SETTINGS_FILES        [label=" /var/lib/sailjail/userdata/\l USER.settings\l"];
+  PASSWD_FILE           [label=" /etc/\l passwd\l"];
+  PERMISSION_FILES      [label=" /etc/sailjail/permissions/\l FEATURE.permission\l"]
+  DESKTOP_FILES         [label=" /usr/share/applications/\l APPLICATION.desktop\l"]
+  DAEMON_CONFIG         [label=" /etc/sailjail/daemon/\l *.config\l"]
+  SERVICE_STATE         [label=" cached\l state\l"]
+  PROMPTER_QUEUE        [label=" request\l queue\l"]
+  PROMPTER_STM          [label=" request\l statemachine\l"]
+  SESSION_STATE         [label=" /run/systemd/\l sessions\l"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * DATAFLOWS (SYNC)
+   * - - - - - - - - - - - - - - - - - - - */
+
+  edge[color=grey30];
+
+  SETTINGS -> USER_SETTINGS       [label=" get\l set\l"];
+
+  USER_SETTINGS -> APP_SETTINGS   [label=" get\l set\l"];
+  USER_SETTINGS -> SETTINGS_FILES [label=" read\l write\l"];
+
+  APP_SETTINGS -> USER_SETTINGS   [label=" dirty\l"];
+  USER_SETTINGS -> SETTINGS       [label=" dirty\l"];
+
+  CONTROL -> SETTINGS             [label=" save\l load\l remove\l"];
+  CONTROL -> SETTINGS             [label=" get\l"];
+
+  CONTROL -> USERS                [label=" min\l max\l"];
+  CONTROL -> USERS                [label=" exists\l"];
+
+  USERS -> PASSWD_FILE            [label=" read\l"];
+
+  CONTROL -> CONFIG               [label=" load\l"];
+  ANY -> CONFIG                   [label=" get\l"];
+  CONFIG -> DAEMON_CONFIG         [label=" read\l"];
+
+  CONTROL -> APPLICATIONS         [label=" list\l"];
+  CONTROL -> APPLICATIONS         [label=" get\l"];
+
+  CONTROL -> PERMISSIONS          [label=" list\l"];
+  CONTROL -> PERMISSIONS          [label=" get\l"];
+  PERMISSIONS -> PERMISSION_FILES [label=" read\l"];
+
+  SERVICE -> CONTROL              [label=" fetch data\l"];
+
+  SERVICE -> SERVICE_STATE;
+
+  PROMPTER -> PROMPTER_QUEUE;
+  PROMPTER -> PROMPTER_STM;
+
+  CONTROL -> SESSION              [label=" get\l"]
+
+  SESSION -> SESSION_STATE        [label=" read\l"]
+
+  APPLICATIONS -> APPINFO         [label=" update\l"];
+  APPINFO -> DESKTOP_FILES        [label=" read\l"];
+  APPLICATIONS -> DESKTOP_FILES   [label=" scan\l"];
+
+  /* - - - - - - - - - - - - - - - - - - - *
+   * DATAFLOWS (ASYNC)
+   * - - - - - - - - - - - - - - - - - - - */
+  edge[color=blue];
+
+  PASSWD_FILE -> USERS            [label=" inotify\l"];
+  USERS -> CONTROL                [label=" changed\l"];
+
+  DESKTOP_FILES -> APPLICATIONS   [label=" inotify\l"];
+  APPLICATIONS -> CONTROL         [label=" changed\l"];
+
+  PERMISSION_FILES -> PERMISSIONS [label=" inotify\l"];
+  PERMISSIONS -> CONTROL          [label=" changed\l"];
+
+  CONTROL -> SERVICE              [label=" broadcast\l"];
+  SERVICE -> DBUS_CLIENT          [label=" signal\l"];
+  SERVICE -> DBUS_CLIENT          [label=" reply\l"];
+  DBUS_CLIENT -> SERVICE          [label=" request\l"];
+
+  SERVICE -> PROMPTER             [label=" queue\l"];
+  PROMPTER -> SERVICE             [label=" finished\l"];
+
+  PROMPTER -> WINDOW_PROMPT       [label=" show\l"];
+  WINDOW_PROMPT -> PROMPTER       [label=" selection\l"];
+
+  SESSION -> CONTROL              [label=" changed\l"]
+
+  SESSION_STATE -> SESSION        [label=" inotify\l"]
+
+  SETTINGS -> CONTROL             [label=" changed\l"];
+}

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -1,0 +1,848 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "service.h"
+
+#include "logging.h"
+#include "mainloop.h"
+#include "prompter.h"
+#include "control.h"
+#include "appinfo.h"
+#include "applications.h"
+#include "permissions.h"
+#include "session.h"
+#include "stringset.h"
+#include "settings.h"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct prompter_t prompter_t;
+
+typedef struct service_t  service_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE
+ * ------------------------------------------------------------------------- */
+
+static void  service_ctor                (service_t *self, control_t *control);
+static void  service_dtor                (service_t *self);
+service_t   *service_create              (control_t *control);
+void         service_delete              (service_t *self);
+void         service_delete_at           (service_t **pself);
+void         service_delete_cb           (void *self);
+void         service_applications_changed(service_t *self, const stringset_t *changed);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+stringset_t *service_filter_permissions(const service_t *self, const stringset_t *permissions);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t             *service_control     (const service_t *self);
+static applications_t *service_applications(const service_t *self);
+static appsettings_t  *service_appsettings (const service_t *self, uid_t uid, const char *app);
+static appinfo_t      *service_appinfo     (const service_t *self, const char *appname);
+prompter_t            *service_prompter    (service_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_CONNECTION
+ * ------------------------------------------------------------------------- */
+
+static GDBusConnection *service_get_connection(const service_t *self);
+static bool             service_has_connection(const service_t *self);
+static void             service_set_connection(service_t *self, GDBusConnection *connection);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void     service_schedule_notify(service_t *self);
+static void     service_cancel_notify  (service_t *self);
+static gboolean service_notify_cb      (gpointer aptr);
+static void     service_notify         (service_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_NAMEOWNER
+ * ------------------------------------------------------------------------- */
+
+static void service_set_nameowner(service_t *self, bool nameowner);
+bool        service_is_nameowner (const service_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_DBUS
+ * ------------------------------------------------------------------------- */
+
+static GDBusInterfaceInfo *service_dbus_interface_info  (const gchar *interface);
+static bool                service_dbus_name_p          (const gchar *name);
+static void                service_dbus_bus_acquired_cb (GDBusConnection *connection, const gchar *name, gpointer user_data);
+static void                service_dbus_name_acquired_cb(GDBusConnection *connection, const gchar *name, gpointer user_data);
+static void                service_dbus_name_lost_cb    (GDBusConnection *connection, const gchar *name, gpointer user_data);
+static void                service_dbus_call_cb         (GDBusConnection *connection, const gchar *sender, const gchar *object_path, const gchar *interface_name, const gchar *method_name, GVariant *parameters, GDBusMethodInvocation *invocation, gpointer user_data);
+static void                service_dbus_emit_signal     (service_t *self, const char *member, const char *value);
+
+/* ========================================================================= *
+ * SERVICE
+ * ========================================================================= */
+
+struct service_t
+{
+    // uplink
+    control_t       *srv_control;
+
+    // data
+    GDBusConnection *srv_dbus_connection;   // service_dbus_bus_acquired_cb()
+    bool             srv_dbus_nameowner;    // service_dbus_name_acquired_cb()
+    guint            srv_dbus_object_id;    // g_dbus_connection_register_object()
+    guint            srv_notify_id;         // service_schedule_notify()
+    stringset_t     *srv_dbus_applications; // signaled applications
+    stringset_t     *srv_permission_filter; // masking: Base,Privileged
+
+    // downlink
+    prompter_t      *srv_prompter;
+
+    // dbus service
+    guint            srv_dbus_name_own_id; // g_bus_own_name()
+};
+
+static void
+service_ctor(service_t *self, control_t *control)
+{
+    log_info("service() create");
+    // uplink
+    self->srv_control = control;
+
+    // data
+    self->srv_dbus_connection   = NULL;
+    self->srv_dbus_nameowner    = false;
+    self->srv_dbus_object_id    = 0;
+    self->srv_notify_id         = 0;
+    self->srv_dbus_applications = stringset_create();
+
+    /* Some permissions must be omitted from prompting */
+    self->srv_permission_filter = stringset_create();
+    stringset_add_item(self->srv_permission_filter, PERMISSION_BASE);
+    stringset_add_item(self->srv_permission_filter, PERMISSION_PRIVILEGED);
+
+    // downlink
+    self->srv_prompter         = prompter_create(self);
+
+    // dbus service
+    self->srv_dbus_name_own_id = g_bus_own_name(PERMISSIONMGR_BUS,
+                                                PERMISSIONMGR_SERVICE,
+                                                G_BUS_NAME_OWNER_FLAGS_DO_NOT_QUEUE,
+                                                service_dbus_bus_acquired_cb,
+                                                service_dbus_name_acquired_cb,
+                                                service_dbus_name_lost_cb,
+                                                self,
+                                                NULL);
+}
+
+static void
+service_dtor(service_t *self)
+{
+    log_info("service() delete");
+
+    // dbus service
+    if( self->srv_dbus_name_own_id ) {
+        g_bus_unown_name(self->srv_dbus_name_own_id),
+            self->srv_dbus_name_own_id = 0;
+    }
+
+    // downlink
+    prompter_delete_at(&self->srv_prompter);
+
+    // connection ref
+    service_set_connection(self, NULL);
+
+    // data
+    service_cancel_notify(self);
+    stringset_delete_at(&self->srv_dbus_applications);
+    stringset_delete_at(&self->srv_permission_filter);
+
+}
+
+service_t *
+service_create(control_t *control)
+{
+    service_t *self = g_malloc0(sizeof *self);
+    service_ctor(self, control);
+    return self;
+}
+
+void
+service_delete(service_t *self)
+{
+    if( self ) {
+        service_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+service_delete_at(service_t **pself)
+{
+    service_delete(*pself), *pself = NULL;
+}
+
+void
+service_delete_cb(void *self)
+{
+    service_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+stringset_t *
+service_filter_permissions(const service_t *self, const stringset_t *permissions)
+{
+    /* Mask out permissions that we do not want to show in prompt */
+    stringset_t *filtered = stringset_filter_out(permissions,
+                                                 self->srv_permission_filter);
+
+    /* But masking must not lead into auto-allow Privileged */
+    if( stringset_empty(filtered) ) {
+        if( stringset_has_item(permissions, PERMISSION_PRIVILEGED) )
+            stringset_add_item(filtered, PERMISSION_PRIVILEGED);
+    }
+
+    return filtered;
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t *
+service_control(const service_t *self)
+{
+    return self->srv_control;
+}
+
+static applications_t *
+service_applications(const service_t *self)
+{
+    return control_applications(service_control(self));
+}
+
+static appsettings_t *
+service_appsettings(const service_t *self, uid_t uid, const char *app)
+{
+    return control_appsettings(service_control(self), uid, app);
+}
+
+static appinfo_t *
+service_appinfo(const service_t *self, const char *appname)
+{
+    return control_appinfo(service_control(self), appname);
+}
+
+prompter_t *
+service_prompter(service_t *self)
+{
+    return self->srv_prompter;
+}
+
+#ifdef DEAD_CODE
+static session_t *
+service_session(const service_t *self)
+{
+    return control_session(service_control(self));
+}
+
+static const config_t *
+service_config(const service_t *self)
+{
+    return control_config(service_control(self));
+}
+
+static users_t *
+service_users(const service_t *self)
+{
+    return control_users(service_control(self));
+}
+
+static permissions_t *
+service_permissions(const service_t *self)
+{
+    return control_permissions(service_control(self));
+}
+
+static uid_t
+service_current_user(service_t *self)
+{
+    return session_current_user(service_session(self));
+}
+#endif
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_CONNECTION
+ * ------------------------------------------------------------------------- */
+
+static GDBusConnection *
+service_get_connection(const service_t *self)
+{
+    return self->srv_dbus_connection;
+}
+
+static bool
+service_has_connection(const service_t *self)
+{
+    return service_get_connection(self) != 0;
+}
+
+static void
+service_set_connection(service_t *self, GDBusConnection *connection)
+{
+    static const GDBusInterfaceVTable interface_vtable =
+    {
+        .method_call = service_dbus_call_cb,
+    };
+
+    if( self->srv_dbus_connection != connection ) {
+        log_debug("connection: %p -> %p", self->srv_dbus_connection, connection);
+
+        service_set_nameowner(self, false);
+
+        if( self->srv_dbus_object_id ) {
+            log_debug("obj unregister: %u", self->srv_dbus_object_id);
+            g_dbus_connection_unregister_object(self->srv_dbus_connection, self->srv_dbus_object_id),
+                self->srv_dbus_object_id = 0;
+        }
+
+        if( self->srv_dbus_connection ) {
+            g_object_unref(self->srv_dbus_connection),
+                self->srv_dbus_connection = 0;
+        }
+
+        if( connection ) {
+            self->srv_dbus_connection = g_object_ref(connection);
+
+            self->srv_dbus_object_id =
+                g_dbus_connection_register_object(self->srv_dbus_connection,
+                                                  PERMISSIONMGR_OBJECT,
+                                                  service_dbus_interface_info(PERMISSIONMGR_INTERFACE),
+                                                  &interface_vtable,
+                                                  self,
+                                                  NULL,
+                                                  NULL);
+            log_debug("obj register: %u", self->srv_dbus_object_id);
+        }
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void
+service_schedule_notify(service_t *self)
+{
+#if PERMISSIONMGR_NOTIFY_DELAY <= 0
+    if( !self->srv_notify_id ) {
+        self->srv_notify_id = g_idle_add(service_notify_cb, self);
+    }
+#else
+    if( self->srv_notify_id )
+        g_source_remove(self->srv_notify_id);
+    self->srv_notify_id = g_timeout_add(PERMISSIONMGR_NOTIFY_DELAY, service_notify_cb, self);
+#endif
+}
+
+static void
+service_cancel_notify(service_t *self)
+{
+    if( self->srv_notify_id ) {
+        g_source_remove(self->srv_notify_id),
+            self->srv_notify_id = 0;
+    }
+}
+
+static gboolean
+service_notify_cb(gpointer aptr)
+{
+    service_t *self = aptr;
+    self->srv_notify_id = 0;
+    service_notify(self);
+    return G_SOURCE_REMOVE;
+}
+
+static void
+service_notify(service_t *self)
+{
+    service_cancel_notify(self);
+
+    if( service_is_nameowner(self) && service_has_connection(self) ) {
+        // FIXME: do we want initial state broadcast?
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_NAMEOWNER
+ * ------------------------------------------------------------------------- */
+
+static void
+service_set_nameowner(service_t *self, bool nameowner)
+{
+    if( self->srv_dbus_nameowner != nameowner ) {
+        log_info("nameowner: %d -> %d", self->srv_dbus_nameowner, nameowner);
+        self->srv_dbus_nameowner = nameowner;
+
+        if( self->srv_dbus_nameowner )
+            service_schedule_notify(self);
+    }
+}
+
+bool
+service_is_nameowner(const service_t *self)
+{
+    return self->srv_dbus_nameowner;
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_DBUS
+ * ------------------------------------------------------------------------- */
+
+static const gchar introspect_xml[] =\
+"<node>"
+"  <interface name='" PERMISSIONMGR_INTERFACE "'>"
+"    <method name='" PERMISSIONMGR_METHOD_QUIT "'>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_GET_APPLICATIONS "'>"
+"      <arg type='as' name='applications' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_GET_APPINFO "'>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='a{sv}' name='appinfo' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_GET_LICENSE "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='i' name='agreed' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_SET_LICENSE "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='i' name='agreed' direction='in'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_GET_LAUNCHABLE "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='i' name='allowed' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_SET_LAUNCHABLE "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='i' name='allowed' direction='in'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_GET_GRANTED "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='as' name='permissions' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_SET_GRANTED "'>"
+"      <arg type='u' name='uid' direction='in'/>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='as' name='permissions' direction='in'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_PROMPT "'>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='as' name='granted' direction='out'/>"
+"    </method>"
+
+"    <method name='" PERMISSIONMGR_METHOD_QUERY "'>"
+"      <arg type='s' name='application' direction='in'/>"
+"      <arg type='as' name='granted' direction='out'/>"
+"    </method>"
+
+"    <signal name='" PERMISSIONMGR_SIGNAL_APP_ADDED "'>"
+"      <arg type='s' name='application'/>"
+"    </signal>"
+
+"    <signal name='" PERMISSIONMGR_SIGNAL_APP_CHANGED "'>"
+"      <arg type='s' name='application'/>"
+"    </signal>"
+
+"    <signal name='" PERMISSIONMGR_SIGNAL_APP_REMOVED "'>"
+"      <arg type='s' name='application'/>"
+"    </signal>"
+"  </interface>"
+"</node>";
+
+static GDBusInterfaceInfo *
+service_dbus_interface_info(const gchar *interface)
+{
+    static GDBusNodeInfo *introspect_data = NULL;
+    if( !introspect_data )
+        introspect_data = g_dbus_node_info_new_for_xml(introspect_xml, NULL);
+    return g_dbus_node_info_lookup_interface(introspect_data, interface);
+}
+
+static bool
+service_dbus_name_p(const gchar *name)
+{
+    return !g_strcmp0(name, PERMISSIONMGR_SERVICE);
+}
+
+static void
+service_dbus_bus_acquired_cb(GDBusConnection *connection,
+                             const gchar *name,
+                             gpointer user_data)
+{
+    service_t *self = user_data;
+
+    if( service_dbus_name_p(name) ) {
+        log_notice("dbus connection acquired");
+        service_set_connection(self, connection);
+    }
+}
+
+static void
+service_dbus_name_acquired_cb(GDBusConnection *connection,
+                              const gchar *name,
+                              gpointer user_data)
+{
+    service_t *self = user_data;
+
+    if( service_dbus_name_p(name) ) {
+        log_notice("dbus name acquired");
+        service_set_nameowner(self, true);
+    }
+}
+
+static void
+service_dbus_name_lost_cb(GDBusConnection *connection,
+                          const gchar *name,
+                          gpointer user_data)
+{
+    service_t *self = user_data;
+    if( !connection ) {
+        log_err("dbus connect failed");
+        app_quit();
+    }
+    else if( service_dbus_name_p(name) ) {
+        log_err("dbus name lost");
+        service_set_nameowner(self, false);
+        app_quit();
+    }
+}
+
+static void
+service_dbus_call_cb(GDBusConnection       *connection,
+                     const gchar           *sender,
+                     const gchar           *object_path,
+                     const gchar           *interface_name,
+                     const gchar           *method_name,
+                     GVariant              *parameters,
+                     GDBusMethodInvocation *invocation,
+                     gpointer               user_data)
+{
+    service_t *self = user_data;
+
+    log_debug("from=%s object=%s method=%s.%s",
+              sender, object_path, interface_name, method_name);
+
+    auto void value_reply(GVariant *val) {
+        log_debug("reply(%p)", val);
+        g_dbus_method_invocation_return_value(invocation,
+                                              val
+                                              ? g_variant_new_tuple(&val, 1)
+                                              : NULL);
+    }
+
+    auto void __attribute__((format(printf, 2, 3))) error_reply(int code, const gchar *fmt, ...) {
+        va_list va;
+        va_start(va, fmt);
+        g_dbus_method_invocation_return_error_valist(invocation, G_DBUS_ERROR,
+                                                     code, fmt, va);
+        va_end(va);
+    }
+
+    if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_GET_APPLICATIONS) ) {
+        GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("as"));
+        const stringset_t *apps = applications_available(service_applications(self));
+        for( const GList *iter = stringset_list(apps); iter; iter = iter->next ) {
+            const char *appname = iter->data;
+            g_variant_builder_add(builder, "s", appname);
+        }
+        GVariant *variant = g_variant_builder_end(builder);
+        g_variant_builder_unref(builder);
+        value_reply(variant);
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_GET_APPINFO) ) {
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(&s)", &app);
+        appinfo_t *appinfo = service_appinfo(self, app);
+        if( !appinfo ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            GVariant *variant = appinfo_to_variant(appinfo);
+            value_reply(variant);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_GET_LICENSE) ) {
+        guint32      uid = SESSION_UID_UNDEFINED;
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(u&s)", &uid, &app);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            app_agreed_t agreed = appsettings_get_agreed(appsettings);
+            GVariant *variant = g_variant_new_int32(agreed);
+            value_reply(variant);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_SET_LICENSE) ) {
+        guint32      uid   = SESSION_UID_UNDEFINED;
+        const gchar *app   = NULL;
+        gint        agreed = APP_AGREED_UNSET;
+        g_variant_get(parameters, "(u&si)", &uid, &app, &agreed);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            appsettings_set_agreed(appsettings, agreed);
+            value_reply(NULL);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_GET_LAUNCHABLE) ) {
+        guint32      uid = SESSION_UID_UNDEFINED;
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(u&s)", &uid, &app);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            app_allowed_t allowed = appsettings_get_allowed(appsettings);
+            GVariant *variant = g_variant_new_int32(allowed);
+            value_reply(variant);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_SET_LAUNCHABLE) ) {
+        guint32      uid    = SESSION_UID_UNDEFINED;
+        const gchar *app    = NULL;
+        gint        allowed = APP_ALLOWED_UNSET;
+        g_variant_get(parameters, "(u&si)", &uid, &app, &allowed);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            appsettings_set_allowed(appsettings, allowed);
+            value_reply(NULL);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_GET_GRANTED) ) {
+        guint32      uid = SESSION_UID_UNDEFINED;
+        const gchar *app = NULL;
+        g_variant_get(parameters, "(u&s)", &uid, &app);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else {
+            const stringset_t *granted = appsettings_get_granted(appsettings);
+            gchar **vector = stringset_to_strv(granted);
+            GVariant *variant = g_variant_new_strv((const gchar * const *)vector, -1);
+            value_reply(variant);
+            g_strfreev(vector);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_SET_GRANTED) ) {
+        guint32      uid = SESSION_UID_UNDEFINED;
+        const gchar *app = NULL;
+        gchar **vector   = NULL;
+        g_variant_get(parameters, "(u&s^as)", &uid, &app, &vector);
+        appsettings_t *appsettings = NULL;
+        if( !control_valid_user(service_control(self), uid) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else if( !vector ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_PERMISSIONS);
+        }
+        else {
+            stringset_t *granted = stringset_from_strv(vector);
+            appsettings_set_granted(appsettings, granted);
+            stringset_delete(granted);
+            value_reply(NULL);
+        }
+        g_strfreev(vector);
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_PROMPT) ||
+             !g_strcmp0(method_name, PERMISSIONMGR_METHOD_QUERY) ) {
+        /* Use session user */
+        guint32        uid         = control_current_user(service_control(self));
+        const gchar   *app         = NULL;
+        appinfo_t     *appinfo     = NULL;
+        appsettings_t *appsettings = NULL;
+        g_variant_get(parameters, "(&s)", &app);
+
+        if( !(appinfo = service_appinfo(self, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_APPLICATION, app);
+        }
+        else if( !(appsettings = service_appsettings(self, uid, app)) ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
+        }
+        else {
+            /* Automatically allow apps that do not require any permissions.
+             * Unless they have been explicitly denied earlier.
+             */
+            const stringset_t *permissions = appinfo_get_permissions(appinfo);
+            stringset_t *filtered = service_filter_permissions(self,
+                                                               permissions);
+            if( stringset_empty(filtered) ) {
+                if( appsettings_get_allowed(appsettings) == APP_ALLOWED_UNSET )
+                    appsettings_set_allowed(appsettings, APP_ALLOWED_ALWAYS);
+            }
+            /* Check current status and reply immediately / queue for prompting.
+             */
+            app_allowed_t allowed = appsettings_get_allowed(appsettings);
+            if( allowed == APP_ALLOWED_NEVER ) {
+                error_reply(G_DBUS_ERROR_AUTH_FAILED, SERVICE_MESSAGE_DENIED_PERMANENTLY);
+            }
+            else if( allowed == APP_ALLOWED_ALWAYS ) {
+                const stringset_t *granted = appsettings_get_granted(appsettings);
+                gchar **vector = stringset_to_strv(granted);
+                GVariant *variant = g_variant_new_strv((const gchar * const *)vector, -1);
+                value_reply(variant);
+                g_strfreev(vector);
+            }
+            else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_QUERY) ) {
+                error_reply(G_DBUS_ERROR_AUTH_FAILED, SERVICE_MESSAGE_NOT_ALLOWED);
+            }
+            else {
+                prompter_handle_invocation(service_prompter(self), invocation);
+            }
+            stringset_delete(filtered);
+        }
+    }
+    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_QUIT) ) {
+        value_reply(NULL);
+        app_quit();
+    }
+    else {
+        error_reply(G_DBUS_ERROR_UNKNOWN_METHOD, "Unknown method: %s",
+                    method_name);
+    }
+    log_debug("done");
+}
+
+static void
+service_dbus_emit_signal(service_t *self, const char *member, const char *value)
+{
+    GDBusConnection *connection = service_get_connection(self);
+    if( !connection ) {
+        log_warning("broadcast %s(%s):  skipped: not connected", member, value);
+    }
+    else{
+        GError *error = 0;
+        g_dbus_connection_emit_signal(connection, NULL,
+                                      PERMISSIONMGR_OBJECT,
+                                      PERMISSIONMGR_INTERFACE,
+                                      member,
+                                      g_variant_new("(s)", value),
+                                      &error);
+        if( error )
+            log_warning("broadcast %s(%s):  failed: %s", member, value, error->message);
+        else
+            log_debug("broadcast %s(%s):  succeeded", member, value);
+        g_clear_error(&error);
+    }
+}
+
+void
+service_applications_changed(service_t *self, const stringset_t *changed)
+{
+    log_notice("*** applications changed broadcast");
+
+    for( const GList *iter = stringset_list(changed); iter; iter = iter->next ) {
+        const char *app = iter->data;
+        appinfo_t *appinfo = service_appinfo(self, app);
+        const char *member = PERMISSIONMGR_SIGNAL_APP_CHANGED;
+        if( !appinfo_valid(appinfo) ) {
+            member = PERMISSIONMGR_SIGNAL_APP_REMOVED;
+            stringset_remove_item(self->srv_dbus_applications, app);
+        }
+        else if( !stringset_has_item(self->srv_dbus_applications, app) ) {
+            member = PERMISSIONMGR_SIGNAL_APP_ADDED;
+            stringset_add_item(self->srv_dbus_applications, app);
+        }
+        service_dbus_emit_signal(self, member, app);
+    }
+}

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  SERVICE_H_
+# define SERVICE_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS;
+
+/* ========================================================================= *
+ * DBUS
+ * ========================================================================= */
+
+# define WINDOWPROMT_SERVICE                   "com.jolla.windowprompt"
+# define WINDOWPROMT_OBJECT                    "/com/jolla/windowprompt"
+# define WINDOWPROMT_INTERFACE                 "com.jolla.windowprompt"
+# define WINDOWPROMT_METHOD_PROMPT             "showPermissionPrompt"
+
+# define PERMISSIONMGR_BUS                     G_BUS_TYPE_SYSTEM
+
+# define PERMISSIONMGR_SERVICE                 "org.sailfishos.sailjaild1"
+# define PERMISSIONMGR_INTERFACE               "org.sailfishos.sailjaild1"
+# define PERMISSIONMGR_OBJECT                  "/org/sailfishos/sailjaild1"
+# define PERMISSIONMGR_METHOD_QUIT             "Quit"
+# define PERMISSIONMGR_METHOD_PROMPT           "PromptLaunchPermissions"
+# define PERMISSIONMGR_METHOD_QUERY            "QueryLaunchPermissions"
+# define PERMISSIONMGR_METHOD_GET_APPLICATIONS "GetApplications"
+# define PERMISSIONMGR_METHOD_GET_APPINFO      "GetAppInfo"
+# define PERMISSIONMGR_METHOD_GET_LICENSE      "GetLicenseAgreed"
+# define PERMISSIONMGR_METHOD_SET_LICENSE      "SetLicenseAgreed"
+# define PERMISSIONMGR_METHOD_GET_LAUNCHABLE   "GetLaunchAllowed"
+# define PERMISSIONMGR_METHOD_SET_LAUNCHABLE   "SetLaunchAllowed"
+# define PERMISSIONMGR_METHOD_GET_GRANTED      "GetGrantedPermissions"
+# define PERMISSIONMGR_METHOD_SET_GRANTED      "SetGrantedPermissions"
+# define PERMISSIONMGR_SIGNAL_APP_ADDED        "ApplicationAdded"
+# define PERMISSIONMGR_SIGNAL_APP_CHANGED      "ApplicationChanged"
+# define PERMISSIONMGR_SIGNAL_APP_REMOVED      "ApplicationRemoved"
+
+/* Message templates used for error reporting */
+# define SERVICE_MESSAGE_INVALID_APPLICATION   "Invalid application name: %s"
+# define SERVICE_MESSAGE_INVALID_USER          "Invalid user id: %u"
+# define SERVICE_MESSAGE_INVALID_PERMISSIONS   "Invalid permissions list"
+# define SERVICE_MESSAGE_DENIED_PERMANENTLY    "Denied permanently"
+# define SERVICE_MESSAGE_NOT_ALLOWED           "Not allowed"
+
+# define PERMISSIONMGR_NOTIFY_DELAY            0 // [ms]
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t       config_t;
+typedef struct users_t        users_t;
+typedef struct session_t      session_t;
+typedef struct permissions_t  permissions_t;
+typedef struct applications_t applications_t;
+typedef struct control_t      control_t;
+typedef struct service_t      service_t;
+typedef struct appinfo_t      appinfo_t;
+typedef struct stringset_t    stringset_t;
+typedef struct prompter_t     prompter_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE
+ * ------------------------------------------------------------------------- */
+
+service_t *service_create              (control_t *control);
+void       service_delete              (service_t *self);
+void       service_delete_at           (service_t **pself);
+void       service_delete_cb           (void *self);
+void       service_applications_changed(service_t *self, const stringset_t *changed);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_PERMISSIONS
+ * ------------------------------------------------------------------------- */
+
+stringset_t *service_filter_permissions(const service_t *self, const stringset_t *permissions);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+control_t  *service_control (const service_t *self);
+prompter_t *service_prompter(service_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SERVICE_NAMEOWNER
+ * ------------------------------------------------------------------------- */
+
+bool service_is_nameowner(const service_t *self);
+
+G_END_DECLS
+
+#endif /* SERVICE_H_ */

--- a/daemon/session.c
+++ b/daemon/session.c
@@ -1,0 +1,348 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "session.h"
+
+#include "control.h"
+#include "logging.h"
+#include "util.h"
+
+#include <systemd/sd-login.h>
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SESSION
+ * ------------------------------------------------------------------------- */
+
+session_t *session_create   (control_t *control);
+void       session_delete   (session_t *self);
+void       session_delete_at(session_t **pself);
+void       session_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static control_t *session_control(const session_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_USER
+ * ------------------------------------------------------------------------- */
+
+uid_t session_current_user(const session_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void session_notify_changed(const session_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_MONITOR
+ * ------------------------------------------------------------------------- */
+
+static gboolean session_monitor_cb    (GIOChannel *chn, GIOCondition cnd, gpointer aptr);
+static void     session_start_monitor (session_t *self);
+static void     session_stop_monitor  (session_t *self);
+static void     session_update_monitor(session_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_SEAT
+ * ------------------------------------------------------------------------- */
+
+static uid_t session_get_seat0_uid(void);
+
+/* ========================================================================= *
+ * SESSION
+ * ========================================================================= */
+
+struct session_t
+{
+    bool               ssn_initialized;
+    control_t         *ssn_control;
+
+    /** Currently active user session */
+    uid_t             ssn_active_uid;
+
+    /** Systemd login monitoring object */
+    sd_login_monitor *ssn_monitor_obj;
+
+    /** I/O watch id for ssn_monitor_obj */
+    guint             ssn_monitor_id;
+};
+
+static inline void
+session_ctor(session_t *self, control_t *control)
+{
+    log_info("session() create");
+    self->ssn_initialized = false;
+    self->ssn_control     = control;
+    self->ssn_active_uid  = SESSION_UID_UNDEFINED;
+    self->ssn_monitor_obj = 0;
+    self->ssn_monitor_id  = 0;
+
+    /* Get initial state */
+    session_start_monitor(self);
+    session_update_monitor(self);
+
+    /* Enable notifications */
+    self->ssn_initialized = true;
+}
+
+static inline void
+session_dtor(session_t *self)
+{
+    log_info("session() delete");
+    self->ssn_initialized = false;
+    session_stop_monitor(self);
+}
+
+session_t *
+session_create(control_t *control)
+{
+    session_t *self = g_malloc0(sizeof *self);
+    session_ctor(self, control);
+    return self;
+}
+
+void
+session_delete(session_t *self)
+{
+    if( self ) {
+        session_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+session_delete_at(session_t **pself)
+{
+    session_delete(*pself), *pself = NULL;
+}
+
+void
+session_delete_cb(void *self)
+{
+    session_delete(self);
+}
+
+static control_t *
+session_control(const session_t *self)
+{
+    return self->ssn_control;
+}
+
+/* ========================================================================= *
+ * SESSION_USER
+ * ========================================================================= */
+
+uid_t
+session_current_user(const session_t *self)
+{
+    return self->ssn_active_uid;
+}
+
+static void
+session_notify_changed(const session_t *self)
+{
+    if( self->ssn_initialized ) {
+        log_info("SESSION MONITOR: notify");
+        control_on_session_changed(session_control(self));
+    }
+}
+
+/* ========================================================================= *
+ * SESSION_MONITOR
+ * ========================================================================= */
+
+/** Handle systemd login monitoring wakeups
+ */
+static gboolean
+session_monitor_cb(GIOChannel *chn, GIOCondition cnd, gpointer aptr)
+{
+    (void)chn;
+    session_t *self = aptr;
+    gboolean result = G_SOURCE_REMOVE;
+
+    if( !self->ssn_monitor_id || !self->ssn_monitor_obj )
+        goto EXIT;
+
+    if( cnd & ~G_IO_IN )
+        goto EXIT;
+
+    session_update_monitor(self);
+
+    if( sd_login_monitor_flush(self->ssn_monitor_obj) >= 0 )
+        result = G_SOURCE_CONTINUE;
+
+EXIT:
+    if( result == G_SOURCE_REMOVE && self->ssn_monitor_id ) {
+        log_crit("SESSION MONITOR: disabled");
+        self->ssn_monitor_id = 0;
+        session_stop_monitor(self);
+    }
+
+    return result;
+}
+
+/** Start user session monitoring
+ */
+static void
+session_start_monitor(session_t *self)
+{
+    bool ack = false;
+
+    session_stop_monitor(self);
+
+    if( sd_login_monitor_new("session", &self->ssn_monitor_obj) < 0 )
+        goto EXIT;
+
+    int fd = sd_login_monitor_get_fd(self->ssn_monitor_obj);
+    if( fd < 0 )
+        goto EXIT;
+
+    self->ssn_monitor_id = gutil_add_watch(fd, G_IO_IN,
+                                           session_monitor_cb, self);
+    if( !self->ssn_monitor_id )
+        goto EXIT;
+
+    ack = true;
+
+    log_info("SESSION MONITOR: started");
+
+EXIT:
+    if( !ack )
+        session_stop_monitor(self);
+
+    return;
+}
+
+/** Stop user session monitoring
+ */
+static void
+session_stop_monitor(session_t *self)
+{
+    if( self->ssn_monitor_id ) {
+        log_info("SESSION MONITOR: stopped");
+
+        g_source_remove(self->ssn_monitor_id),
+            self->ssn_monitor_id = 0;
+    }
+
+    if( self->ssn_monitor_obj ) {
+        sd_login_monitor_unref(self->ssn_monitor_obj),
+            self->ssn_monitor_obj = 0;
+    }
+}
+
+static void
+session_update_monitor(session_t *self)
+{
+    uid_t uid = session_get_seat0_uid();
+    if( self->ssn_active_uid != uid ) {
+        log_info("SESSION MONITOR: uid: %d -> %d",
+                 (int)self->ssn_active_uid, (int)uid);
+        self->ssn_active_uid = uid;
+        session_notify_changed(self);
+    }
+}
+
+/* ========================================================================= *
+ * SESSION_SEAT
+ * ========================================================================= */
+
+/** Find uid for user active session at seat0
+ */
+static uid_t
+session_get_seat0_uid(void)
+{
+    uid_t  active_uid = SESSION_UID_UNDEFINED;
+    char **sessions   = 0;
+
+    int rc;
+
+    if( (rc = sd_get_sessions(&sessions)) < 0 ) {
+        log_warning("sd_get_sessions: %s", strerror(-rc));
+        goto EXIT;
+    }
+
+    if( rc < 1 || !sessions )
+        goto EXIT;
+
+    for( size_t i = 0; active_uid == SESSION_UID_UNDEFINED && sessions[i]; ++i ) {
+        uid_t  uid    = SESSION_UID_UNDEFINED;
+        char  *seat   = 0;
+        char  *state  = 0;
+
+        if( (rc = sd_session_get_uid(sessions[i], &uid)) < 0 ) {
+            log_warning("sd_session_get_uid(%s): %s",
+                        sessions[i], strerror(-rc));
+        }
+        else if( (rc = sd_session_get_state(sessions[i], &state)) < 0 ) {
+            log_warning("sd_session_get_state(%s): %s",
+                        sessions[i], strerror(-rc));
+        }
+        else if( (rc = sd_session_get_seat(sessions[i], &seat)) < 0 ) {
+            /* NB: It is normal to have sessions without a seat, but
+             *     sd_session_get_seat() reports error on such cases
+             *     and we do not want that to cause logging noise.
+             */
+        }
+        else if( state && seat && !strcmp(seat, "seat0") ) {
+            if( !strcmp(state, "active") || !strcmp(state, "online") )
+                active_uid = uid;
+        }
+
+        free(state);
+        free(seat);
+    }
+
+EXIT:
+    if( sessions ) {
+        for( size_t i = 0; sessions[i]; ++i )
+            free(sessions[i]);
+        free(sessions);
+    }
+
+    return active_uid;
+}

--- a/daemon/session.h
+++ b/daemon/session.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  SESSION_H_
+# define SESSION_H_
+
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Constants
+ * ========================================================================= */
+
+# define SESSION_UID_UNDEFINED ((uid_t)(-1))
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t       config_t;
+typedef struct session_t      session_t;
+typedef struct control_t      control_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SESSION
+ * ------------------------------------------------------------------------- */
+
+session_t *session_create   (control_t *control);
+void       session_delete   (session_t *self);
+void       session_delete_at(session_t **pself);
+void       session_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * SESSION_USER
+ * ------------------------------------------------------------------------- */
+
+uid_t session_current_user(const session_t *self);
+
+G_END_DECLS
+
+#endif /* SESSION_H_ */

--- a/daemon/settings.c
+++ b/daemon/settings.c
@@ -1,0 +1,1021 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "settings.h"
+
+#include "util.h"
+#include "logging.h"
+#include "stringset.h"
+#include "control.h"
+#include "appinfo.h"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+static const char * const app_allowed_name[APP_ALLOWED_COUNT] = {
+    [APP_ALLOWED_UNSET] = "UNSET",
+    [APP_ALLOWED_ALWAYS]= "ALWAYS",
+    [APP_ALLOWED_NEVER] = "NEVER",
+};
+
+static const char * const app_agreed_name[APP_AGREED_COUNT] = {
+    [APP_AGREED_UNSET] = "UNSET",
+    [APP_AGREED_YES]   = "YES",
+    [APP_AGREED_NO]    = "NO",
+};
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS
+ * ------------------------------------------------------------------------- */
+
+static void  settings_ctor     (settings_t *self, const config_t *config, control_t *control);
+static void  settings_dtor     (settings_t *self);
+settings_t  *settings_create   (const config_t *config, control_t *control);
+void         settings_delete   (settings_t *self);
+void         settings_delete_at(settings_t **pself);
+void         settings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static control_t *settings_control    (const settings_t *self);
+appsettings_t    *settings_appsettings(settings_t *self, uid_t uid, const char *app);
+static bool       settings_initialized(const settings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_USERSETTINGS
+ * ------------------------------------------------------------------------- */
+
+usersettings_t *settings_get_usersettings   (const settings_t *self, uid_t uid);
+usersettings_t *settings_add_usersettings   (settings_t *self, uid_t uid);
+bool            settings_remove_usersettings(settings_t *self, uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_APPSETTING
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *settings_get_appsettings   (const settings_t *self, uid_t uid, const char *appname);
+appsettings_t *settings_add_appsettings   (settings_t *self, uid_t uid, const char *appname);
+bool           settings_remove_appsettings(settings_t *self, uid_t uid, const char *appname);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void            settings_load_all   (settings_t *self);
+void            settings_save_all   (const settings_t *self);
+void            settings_load_user  (settings_t *self, uid_t uid);
+void            settings_save_user  (const settings_t *self, uid_t uid);
+static void     settings_save_now   (settings_t *self);
+static gboolean settings_save_cb    (gpointer aptr);
+static void     settings_cancel_save(settings_t *self);
+void            settings_save_later (settings_t *self, uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+void settings_rethink(settings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_UTILITY
+ * ------------------------------------------------------------------------- */
+
+static gchar *settings_userdata_path(uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS
+ * ------------------------------------------------------------------------- */
+
+static void     usersettings_ctor     (usersettings_t *self, settings_t *settings, uid_t uid);
+static void     usersettings_dtor     (usersettings_t *self);
+usersettings_t *usersettings_create   (settings_t *settings, uid_t uid);
+void            usersettings_delete   (usersettings_t *self);
+void            usersettings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static settings_t *usersettings_settings(const usersettings_t *self);
+static uid_t       usersettings_uid     (const usersettings_t *self);
+static control_t  *usersettings_control (const usersettings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_APPSETTINGS
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *usersettings_get_appsettings   (const usersettings_t *self, const gchar *appname);
+appsettings_t *usersettings_add_appsettings   (usersettings_t *self, const gchar *appname);
+bool           usersettings_remove_appsettings(usersettings_t *self, const gchar *appname);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void usersettings_load(usersettings_t *self, const char *path);
+void usersettings_save(const usersettings_t *self, const char *path);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void usersettings_rethink(usersettings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS
+ * ------------------------------------------------------------------------- */
+
+static void    appsettings_ctor     (appsettings_t *self, usersettings_t *usersettings, const char *appname);
+static void    appsettings_dtor     (appsettings_t *self);
+appsettings_t *appsettings_create   (usersettings_t *usersettings, const char *appname);
+void           appsettings_delete   (appsettings_t *self);
+void           appsettings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static control_t      *appsettings_control     (const appsettings_t *self);
+static settings_t     *appsettings_settings    (const appsettings_t *self);
+static usersettings_t *appsettings_usersettings(const appsettings_t *self);
+static uid_t           appsettings_uid         (appsettings_t *self);
+static const gchar    *appsettings_appname     (const appsettings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void appsettings_notify_change(appsettings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_PROPERTIES
+ * ------------------------------------------------------------------------- */
+
+app_allowed_t      appsettings_get_allowed    (const appsettings_t *self);
+app_agreed_t       appsettings_get_agreed     (const appsettings_t *self);
+const stringset_t *appsettings_get_granted    (appsettings_t *self);
+void               appsettings_set_allowed    (appsettings_t *self, app_allowed_t allowed);
+void               appsettings_set_agreed     (appsettings_t *self, app_agreed_t agreed);
+static void        appsettings_set_permissions(appsettings_t *self, const stringset_t *permissions);
+void               appsettings_set_granted    (appsettings_t *self, const stringset_t *granted);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+static void appsettings_decode(appsettings_t *self, GKeyFile *file);
+static void appsettings_encode(const appsettings_t *self, GKeyFile *file);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void appsettings_rethink(appsettings_t *self);
+
+/* ========================================================================= *
+ * SETTINGS
+ * ========================================================================= */
+
+struct settings_t
+{
+    bool            stt_initialized;
+    const config_t *stt_config;
+    control_t      *stt_control;
+    guint           stt_save_id;
+    GHashTable     *stt_users;
+    GHashTable     *stt_user_changes;
+};
+
+static void
+settings_ctor(settings_t *self, const config_t *config, control_t *control)
+{
+    log_info("settings() created");
+    self->stt_initialized  = false;
+    self->stt_config       = config;
+    self->stt_control      = control;
+    self->stt_save_id      = 0;
+    self->stt_users        = g_hash_table_new_full(g_direct_hash,
+                                                   g_direct_equal,
+                                                   NULL,
+                                                   usersettings_delete_cb);
+    self->stt_user_changes = g_hash_table_new(g_direct_hash, g_direct_equal);
+
+    /* Get initial state */
+    settings_load_all(self);
+
+    /* Enable notifications */
+    self->stt_initialized  = true;
+}
+
+static void
+settings_dtor(settings_t *self)
+{
+    log_info("settings() deleted");
+    self->stt_initialized  = false;
+
+    if( self->stt_users ) {
+        g_hash_table_unref(self->stt_users),
+            self->stt_users = NULL;
+    }
+
+    if( self->stt_user_changes ) {
+        g_hash_table_unref(self->stt_user_changes),
+            self->stt_user_changes = 0;
+    }
+}
+
+settings_t *
+settings_create(const config_t *config, control_t *control)
+{
+    settings_t *self = g_malloc0(sizeof *self);
+    settings_ctor(self, config, control);
+    return self;
+}
+
+void
+settings_delete(settings_t *self)
+{
+    if( self ) {
+        settings_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+settings_delete_at(settings_t **pself)
+{
+    settings_delete(*pself), *pself = NULL;
+}
+
+void
+settings_delete_cb(void *self)
+{
+    settings_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+#ifdef DEAD_CODE
+static const config_t *
+settings_config(const settings_t *self)
+{
+    return self->stt_config;
+}
+#endif
+
+static control_t *
+settings_control(const settings_t *self)
+{
+    return self->stt_control;
+}
+
+appsettings_t *
+settings_appsettings(settings_t *self, uid_t uid, const char *app)
+{
+    appsettings_t *appsettings = NULL;
+    control_t *control = settings_control(self);
+    if( control_valid_user(control, uid) &&
+        control_valid_application(control, app) )
+        appsettings = settings_add_appsettings(self, uid, app);
+    return appsettings;
+}
+
+static bool
+settings_initialized(const settings_t *self)
+{
+    return self->stt_initialized;
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_USERSETTINGS
+ * ------------------------------------------------------------------------- */
+
+usersettings_t *
+settings_get_usersettings(const settings_t *self, uid_t uid)
+{
+    return g_hash_table_lookup(self->stt_users, GINT_TO_POINTER(uid));
+}
+
+usersettings_t *
+settings_add_usersettings(settings_t *self, uid_t uid)
+{
+    usersettings_t *usersettings = settings_get_usersettings(self, uid);
+    if( !usersettings ) {
+        usersettings = usersettings_create(self, uid);
+        g_hash_table_insert(self->stt_users, GINT_TO_POINTER(uid),
+                            usersettings);
+    }
+    return usersettings;
+}
+
+bool
+settings_remove_usersettings(settings_t *self, uid_t uid)
+{
+    return g_hash_table_remove(self->stt_users, GINT_TO_POINTER(uid));
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_APPSETTING
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *
+settings_get_appsettings(const settings_t *self, uid_t uid, const char *appname)
+{
+    appsettings_t *appsettings = NULL;
+    usersettings_t *usersettings = settings_get_usersettings(self, uid);
+    if( usersettings )
+        appsettings = usersettings_get_appsettings(usersettings, appname);
+    return appsettings;
+}
+
+appsettings_t *
+settings_add_appsettings(settings_t *self, uid_t uid, const char *appname)
+{
+    usersettings_t *usersettings = settings_add_usersettings(self, uid);
+    return usersettings_add_appsettings(usersettings, appname);
+}
+
+bool
+settings_remove_appsettings(settings_t *self, uid_t uid, const char *appname)
+{
+    bool removed = false;
+    usersettings_t *usersettings = settings_get_usersettings(self, uid);
+    if( usersettings )
+        removed = usersettings_remove_appsettings(usersettings, appname);
+    return removed;
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void
+settings_load_all(settings_t *self)
+{
+    control_t *control = settings_control(self);
+    uid_t min_uid = control_min_user(control);
+    uid_t max_uid = control_max_user(control);
+
+    for( uid_t uid = min_uid; uid <= max_uid; ++uid )
+        settings_load_user(self, uid);
+}
+
+void
+settings_save_all(const settings_t *self)
+{
+    control_t *control = settings_control(self);
+    uid_t min_uid = control_min_user(control);
+    uid_t max_uid = control_max_user(control);
+
+    for( uid_t uid = min_uid; uid <= max_uid; ++uid )
+        settings_save_user(self, uid);
+}
+
+void
+settings_load_user(settings_t *self, uid_t uid)
+{
+    if( control_valid_user(settings_control(self), uid) ) {
+        gchar *path = settings_userdata_path(uid);
+        usersettings_t *usersettings = settings_add_usersettings(self, uid);
+        usersettings_load(usersettings, path);
+        g_free(path);
+    }
+}
+
+void
+settings_save_user(const settings_t *self, uid_t uid)
+{
+
+    if( control_valid_user(settings_control(self), uid) ) {
+        gchar *path = settings_userdata_path(uid);
+        usersettings_t *usersettings = settings_get_usersettings(self, uid);
+        if( usersettings )
+            usersettings_save(usersettings, path);
+        g_free(path);
+    }
+}
+
+static void
+settings_save_now(settings_t *self)
+{
+    settings_cancel_save(self);
+
+    GHashTableIter iter;
+    gpointer key, value;
+
+    g_hash_table_iter_init(&iter, self->stt_user_changes);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        uid_t uid = GPOINTER_TO_UINT(key);
+        settings_save_user(self, uid);
+    }
+
+    g_hash_table_remove_all(self->stt_user_changes);
+}
+
+static gboolean
+settings_save_cb(gpointer aptr)
+{
+    settings_t *self = aptr;
+    self->stt_save_id = 0;
+    settings_save_now(self);
+    return G_SOURCE_REMOVE;
+}
+
+static void
+settings_cancel_save(settings_t *self)
+{
+    if( self->stt_save_id ) {
+        g_source_remove(self->stt_save_id),
+            self->stt_save_id = 0;
+    }
+}
+
+void
+settings_save_later(settings_t *self, uid_t uid)
+{
+    g_hash_table_add(self->stt_user_changes, GINT_TO_POINTER(uid));
+
+    if( !self->stt_save_id ) {
+        self->stt_save_id = g_timeout_add(1000, settings_save_cb, self);
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+void
+settings_rethink(settings_t *self)
+{
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, self->stt_users);
+    while( g_hash_table_iter_next(&iter, &key, &value) )
+        usersettings_rethink(value);
+}
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_UTILITY
+ * ------------------------------------------------------------------------- */
+
+static gchar *
+settings_userdata_path(uid_t uid)
+{
+    return g_strdup_printf(SETTINGS_DIRECTORY "/user-%u" SETTINGS_EXTENSION,
+                           (unsigned)uid);
+}
+
+/* ========================================================================= *
+ * USERSETTINGS
+ * ========================================================================= */
+
+struct usersettings_t
+{
+    settings_t *ust_settings;
+    uid_t       ust_uid;
+    GHashTable *ust_apps;
+};
+
+static void
+usersettings_ctor(usersettings_t *self, settings_t *settings, uid_t uid)
+{
+    self->ust_settings = settings;
+    self->ust_uid      = uid;
+    self->ust_apps     = g_hash_table_new_full(g_str_hash,
+                                               g_str_equal,
+                                               g_free,
+                                               appsettings_delete_cb);
+    log_info("usersettings(%d) created", (int)usersettings_uid(self));
+}
+
+static void
+usersettings_dtor(usersettings_t *self)
+{
+    log_info("usersettings(%d) deleted", (int)usersettings_uid(self));
+    if( self->ust_apps ) {
+        g_hash_table_unref(self->ust_apps),
+            self->ust_apps = NULL;
+    }
+}
+
+usersettings_t *
+usersettings_create(settings_t *settings, uid_t uid)
+{
+    usersettings_t *self = g_malloc0(sizeof *self);
+    usersettings_ctor(self, settings, uid);
+    return self;
+}
+
+void
+usersettings_delete(usersettings_t *self)
+{
+    if( self ) {
+        usersettings_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+usersettings_delete_cb(void *self)
+{
+    usersettings_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static settings_t *
+usersettings_settings(const usersettings_t *self)
+{
+    return self->ust_settings;
+}
+
+static uid_t
+usersettings_uid(const usersettings_t *self)
+{
+    return self->ust_uid;
+}
+
+#ifdef DEAD_CODE
+static const config_t *
+usersettings_config(const usersettings_t *self)
+{
+    return settings_config(usersettings_settings(self));
+}
+#endif
+
+static control_t *
+usersettings_control(const usersettings_t *self)
+{
+    return settings_control(usersettings_settings(self));
+}
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_APPSETTINGS
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *
+usersettings_get_appsettings(const usersettings_t *self, const gchar *appname)
+{
+    return g_hash_table_lookup(self->ust_apps, appname);
+}
+
+appsettings_t *
+usersettings_add_appsettings(usersettings_t *self, const gchar *appname)
+{
+    appsettings_t *appsettings = usersettings_get_appsettings(self, appname);
+    if( !appsettings ) {
+        appsettings = appsettings_create(self, appname);
+        g_hash_table_insert(self->ust_apps, g_strdup(appname), appsettings);
+    }
+    return appsettings;
+}
+
+bool
+usersettings_remove_appsettings(usersettings_t *self, const gchar *appname)
+{
+    return g_hash_table_remove(self->ust_apps, appname);
+}
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void
+usersettings_load(usersettings_t *self, const char *path)
+{
+    GKeyFile *file = g_key_file_new();
+    keyfile_load(file, path);
+    gchar **groups = g_key_file_get_groups(file, NULL);
+    if( groups ) {
+        for( size_t i = 0; groups[i]; ++i ) {
+            const char *appname = groups[i];
+            if( control_valid_application(usersettings_control(self), appname) ) {
+                appsettings_t *appsettings =
+                    usersettings_add_appsettings(self, appname);
+                appsettings_decode(appsettings, file);
+            }
+        }
+        g_strfreev(groups);
+    }
+    g_key_file_unref(file);
+}
+
+void
+usersettings_save(const usersettings_t *self, const char *path)
+{
+    GKeyFile *file = g_key_file_new();
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, self->ust_apps);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        const char *appname = key;
+        if( control_valid_application(usersettings_control(self), appname) ) {
+            appsettings_t *appsettings = value;
+            appsettings_encode(appsettings, file);
+        }
+    }
+    keyfile_save(file, path);
+    g_key_file_unref(file);
+}
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void
+usersettings_rethink(usersettings_t *self)
+{
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, self->ust_apps);
+    while( g_hash_table_iter_next(&iter, &key, &value) )
+        appsettings_rethink(value);
+}
+
+/* ========================================================================= *
+ * APPSETTINGS
+ * ========================================================================= */
+
+struct appsettings_t
+{
+    usersettings_t *ast_usersettings;
+    gchar          *ast_appname;
+
+    app_allowed_t   ast_allowed;
+    app_agreed_t    ast_agreed;
+    stringset_t    *ast_granted;
+    stringset_t    *ast_permissions;
+};
+
+static void
+appsettings_ctor(appsettings_t *self, usersettings_t *usersettings,
+                 const char *appname)
+{
+    self->ast_usersettings = usersettings;
+    self->ast_appname      = g_strdup(appname);
+
+    self->ast_allowed      = APP_ALLOWED_UNSET;
+    self->ast_agreed       = APP_AGREED_UNSET;
+    self->ast_granted      = stringset_create();
+    self->ast_permissions  = stringset_create();
+
+    log_info("appsettings(%d, %s) created",
+             (int)usersettings_uid(appsettings_usersettings(self)),
+             appsettings_appname(self));
+
+    /* Evaluate derived values to ensure sane initial state */
+    appsettings_rethink(self);
+}
+
+static void
+appsettings_dtor(appsettings_t *self)
+{
+    log_info("appsettings(%d, %s) deleted",
+             (int)usersettings_uid(appsettings_usersettings(self)),
+             appsettings_appname(self));
+
+    change_string(&self->ast_appname, NULL);
+    stringset_delete_at(&self->ast_granted);
+    stringset_delete_at(&self->ast_permissions);
+}
+
+appsettings_t *
+appsettings_create(usersettings_t *usersettings, const char *appname)
+{
+    appsettings_t *self = g_malloc0(sizeof *self);
+    appsettings_ctor(self, usersettings, appname);
+    return self;
+}
+
+void
+appsettings_delete(appsettings_t *self)
+{
+    if( self ) {
+        appsettings_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+appsettings_delete_cb(void *self)
+{
+    appsettings_delete(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+#ifdef DEAD_CODE
+static const config_t *
+appsettings_config(const appsettings_t *self)
+{
+    return usersettings_config(appsettings_usersettings(self));
+}
+#endif
+
+static control_t *
+appsettings_control(const appsettings_t *self)
+{
+    return settings_control(appsettings_settings(self));
+}
+
+static settings_t *
+appsettings_settings(const appsettings_t *self)
+{
+    return usersettings_settings(appsettings_usersettings(self));
+}
+
+static usersettings_t *
+appsettings_usersettings(const appsettings_t *self)
+{
+    return self->ast_usersettings;
+}
+
+static uid_t
+appsettings_uid(appsettings_t *self)
+{
+    return usersettings_uid(appsettings_usersettings(self));
+}
+
+static const gchar *
+appsettings_appname(const appsettings_t *self)
+{
+    return self->ast_appname;
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void
+appsettings_notify_change(appsettings_t *self)
+{
+    /* Forward application changes upwards */
+    if( settings_initialized(appsettings_settings(self)) )
+        control_on_settings_change(appsettings_control(self),
+                                   appsettings_appname(self));
+
+    /* Schedule user settings saving */
+    settings_save_later(appsettings_settings(self),
+                        appsettings_uid(self));
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_PROPERTIES
+ * ------------------------------------------------------------------------- */
+
+app_allowed_t
+appsettings_get_allowed(const appsettings_t *self)
+{
+    return self->ast_allowed;
+}
+
+app_agreed_t
+appsettings_get_agreed(const appsettings_t *self)
+{
+    return self->ast_agreed;
+}
+
+const stringset_t *
+appsettings_get_granted(appsettings_t *self)
+{
+    return self->ast_granted;
+}
+
+void
+appsettings_set_allowed(appsettings_t *self, app_allowed_t allowed)
+{
+    if( (unsigned)allowed >= APP_ALLOWED_COUNT )
+        allowed = APP_ALLOWED_UNSET;
+
+    if( self->ast_allowed != allowed ) {
+        self->ast_allowed = allowed;
+        log_debug("[%u] %s: allowed = %s",
+                  appsettings_uid(self),
+                  appsettings_appname(self),
+                  app_allowed_name[allowed]);
+        appsettings_notify_change(self);
+
+        const stringset_t *granted = NULL;
+        if( allowed == APP_ALLOWED_ALWAYS ) {
+            appinfo_t *appinfo = control_appinfo(appsettings_control(self),
+                                                 appsettings_appname(self));
+            if( appinfo )
+                granted = appinfo_get_permissions(appinfo);
+        }
+        appsettings_set_granted(self, granted);
+    }
+}
+
+void
+appsettings_set_agreed(appsettings_t *self, app_agreed_t agreed)
+{
+    if( (unsigned)agreed >= APP_AGREED_COUNT  )
+        agreed = APP_AGREED_UNSET;
+
+    if( self->ast_agreed != agreed ) {
+        self->ast_agreed = agreed;
+        log_debug("[%u] %s: agreed = %s",
+                  appsettings_uid(self),
+                  appsettings_appname(self),
+                  app_agreed_name[agreed]);
+        appsettings_notify_change(self);
+    }
+}
+
+static void
+appsettings_set_permissions(appsettings_t *self, const stringset_t *permissions)
+{
+    if( !stringset_equal(self->ast_permissions, permissions) ) {
+        /* If new permissions have been added to application desktop:
+         * user must be prompted again.
+         *
+         * Note that in order to minimize recursion noise, permission
+         * bookkeeping changes must be done before executing allow
+         * value reset.
+         */
+        bool reset_allow = false;
+
+        if( appsettings_get_allowed(self) == APP_ALLOWED_ALWAYS ) {
+            stringset_t * added = stringset_filter_out(permissions,
+                                                       self->ast_permissions);
+            if( !stringset_empty(added) ) {
+                if( log_p(LOG_DEBUG) ) {
+                    gchar *text = stringset_to_string(added);
+                    log_debug("[%u] %s: added permissions = %s",
+                              appsettings_uid(self),
+                              appsettings_appname(self),
+                              text);
+                    g_free(text);
+                }
+                reset_allow = true;
+            }
+            stringset_delete(added);
+        }
+
+        if( stringset_assign(self->ast_permissions, permissions) ) {
+            if( log_p(LOG_DEBUG) ) {
+                gchar *text = stringset_to_string(self->ast_permissions);
+                log_debug("[%u] %s: permissions = %s",
+                          appsettings_uid(self),
+                          appsettings_appname(self),
+                          text);
+                g_free(text);
+            }
+            appsettings_notify_change(self);
+        }
+
+        if( reset_allow )
+            appsettings_set_allowed(self, APP_ALLOWED_UNSET);
+    }
+}
+
+void
+appsettings_set_granted(appsettings_t *self, const stringset_t *granted)
+{
+    /* Note: This must be kept so that it works also when
+     *       'granted' arg is actually the current value,
+     *       so that it can be used also for re-evaluating
+     *       state after desktop file changes.
+     */
+
+    stringset_t *dummy = stringset_create();
+    stringset_t *effective = NULL;
+
+    /* Clear / keep cleared while not allowed */
+    if( appsettings_get_allowed(self) != APP_ALLOWED_ALWAYS )
+        granted = NULL;
+
+    /* Allow use of granted=NULL to clear */
+    if( !granted )
+        granted = dummy;
+
+    /* Limit to subset of permissions defined in application desktop.
+     *
+     * Note: we might get here due to desktop file removal, and thus
+     *       need to handle no-appinfo-available case gracefully.
+     */
+
+    appinfo_t *appinfo = control_appinfo(appsettings_control(self),
+                                         appsettings_appname(self));
+
+    const stringset_t *permissions = (appinfo_valid(appinfo) ?
+                                      appinfo_get_permissions(appinfo) :
+                                      dummy);
+
+    effective = stringset_filter_in(granted, permissions);
+
+    if( stringset_assign(self->ast_granted, effective) ) {
+        if( log_p(LOG_DEBUG) ) {
+            gchar *text = stringset_to_string(self->ast_granted);
+            log_debug("[%u] %s: granted = %s",
+                      appsettings_uid(self),
+                      appsettings_appname(self),
+                      text);
+            g_free(text);
+        }
+        appsettings_notify_change(self);
+    }
+
+    /* Record what application permissions were used in above evaluation */
+    appsettings_set_permissions(self, permissions);
+
+    stringset_delete(effective);
+    stringset_delete(dummy);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+static void
+appsettings_decode(appsettings_t *self, GKeyFile *file)
+{
+    const char *sec = appsettings_appname(self);
+    self->ast_allowed = keyfile_get_integer(file, sec, "Allowed",
+                                            APP_ALLOWED_UNSET);
+    self->ast_agreed  = keyfile_get_integer(file, sec, "Agreed",
+                                            APP_AGREED_UNSET);
+
+    /* 'Permissions' value is internal caching at appsettings level.
+     * It must be taken as-is from keyfile (and re-evaluated in
+     * context of 'Granted' value handling below).
+     */
+    stringset_delete_at(&self->ast_permissions);
+    self->ast_permissions = keyfile_get_stringset(file, sec, "Permissions");
+
+    /* 'Granted' needs to be subjected to permissions available in
+     * system, permissions requested in desktop file and current
+     * state of 'allowed' setting -> it needs to be pushed through
+     * evaluator rather than being used as-is.
+     */
+    stringset_t *granted = keyfile_get_stringset(file, sec, "Granted");
+    appsettings_set_granted(self, granted);
+    stringset_delete(granted);
+}
+
+static void
+appsettings_encode(const appsettings_t *self, GKeyFile *file)
+{
+    const char *sec = appsettings_appname(self);
+    keyfile_set_integer(file, sec, "Allowed", self->ast_allowed);
+    keyfile_set_integer(file, sec, "Agreed", self->ast_agreed);
+    keyfile_set_stringset(file, sec, "Granted", self->ast_granted);
+    keyfile_set_stringset(file, sec, "Permissions", self->ast_permissions);
+}
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+static void
+appsettings_rethink(appsettings_t *self)
+{
+    /* Assign current value -> masking is re-applied */
+    appsettings_set_granted(self, self->ast_granted);
+}

--- a/daemon/settings.h
+++ b/daemon/settings.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  SETTINGS_H_
+# define SETTINGS_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct config_t       config_t;
+typedef struct settings_t     settings_t;
+typedef struct usersettings_t usersettings_t;
+typedef struct appsettings_t  appsettings_t;
+typedef struct control_t      control_t;
+typedef struct stringset_t    stringset_t;
+
+typedef enum
+{
+    APP_ALLOWED_UNSET,
+    APP_ALLOWED_ALWAYS,
+    APP_ALLOWED_NEVER,
+    APP_ALLOWED_COUNT
+    // keep app_allowed_name[] in sync
+} app_allowed_t;
+
+typedef enum
+{
+    APP_AGREED_UNSET,
+    APP_AGREED_YES,
+    APP_AGREED_NO,
+    APP_AGREED_COUNT
+    // keep app_agreed_name[] in sync
+} app_agreed_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS
+ * ------------------------------------------------------------------------- */
+
+settings_t *settings_create   (const config_t *config, control_t *control);
+void        settings_delete   (settings_t *self);
+void        settings_delete_at(settings_t **pself);
+void        settings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *settings_appsettings(settings_t *self, uid_t uid, const char *app);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_USERSETTINGS
+ * ------------------------------------------------------------------------- */
+
+usersettings_t *settings_get_usersettings   (const settings_t *self, uid_t uid);
+usersettings_t *settings_add_usersettings   (settings_t *self, uid_t uid);
+bool            settings_remove_usersettings(settings_t *self, uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_APPSETTING
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *settings_get_appsettings   (const settings_t *self, uid_t uid, const char *appname);
+appsettings_t *settings_add_appsettings   (settings_t *self, uid_t uid, const char *appname);
+bool           settings_remove_appsettings(settings_t *self, uid_t uid, const char *appname);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void settings_load_all  (settings_t *self);
+void settings_save_all  (const settings_t *self);
+void settings_load_user (settings_t *self, uid_t uid);
+void settings_save_user (const settings_t *self, uid_t uid);
+void settings_save_later(settings_t *self, uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * SETTINGS_RETHINK
+ * ------------------------------------------------------------------------- */
+
+void settings_rethink(settings_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS
+ * ------------------------------------------------------------------------- */
+
+usersettings_t *usersettings_create   (settings_t *settings, uid_t uid);
+void            usersettings_delete   (usersettings_t *self);
+void            usersettings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_APPSETTINGS
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *usersettings_get_appsettings   (const usersettings_t *self, const gchar *appname);
+appsettings_t *usersettings_add_appsettings   (usersettings_t *self, const gchar *appname);
+bool           usersettings_remove_appsettings(usersettings_t *self, const gchar *appname);
+
+/* ------------------------------------------------------------------------- *
+ * USERSETTINGS_STORAGE
+ * ------------------------------------------------------------------------- */
+
+void usersettings_load(usersettings_t *self, const char *path);
+void usersettings_save(const usersettings_t *self, const char *path);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS
+ * ------------------------------------------------------------------------- */
+
+appsettings_t *appsettings_create   (usersettings_t *usersettings, const char *appname);
+void           appsettings_delete   (appsettings_t *self);
+void           appsettings_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSETTINGS_PROPERTIES
+ * ------------------------------------------------------------------------- */
+
+app_allowed_t      appsettings_get_allowed(const appsettings_t *self);
+app_agreed_t       appsettings_get_agreed (const appsettings_t *self);
+const stringset_t *appsettings_get_granted(appsettings_t *self);
+void               appsettings_set_allowed(appsettings_t *self, app_allowed_t allowed);
+void               appsettings_set_agreed (appsettings_t *self, app_agreed_t agreed);
+void               appsettings_set_granted(appsettings_t *self, const stringset_t *granted);
+
+G_END_DECLS
+
+#endif /* SETTINGS_H_ */

--- a/daemon/stringset.c
+++ b/daemon/stringset.c
@@ -1,0 +1,335 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "stringset.h"
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+static void   stringset_ctor       (stringset_t *self);
+static void   stringset_dtor       (stringset_t *self);
+stringset_t  *stringset_create     (void);
+void          stringset_delete     (stringset_t *self);
+void          stringset_delete_at  (stringset_t **pself);
+void          stringset_delete_cb  (void *self);
+guint         stringset_size       (const stringset_t *self);
+bool          stringset_empty      (const stringset_t *self);
+const GList  *stringset_list       (const stringset_t *self);
+bool          stringset_has_item   (const stringset_t *self, const gchar *item);
+bool          stringset_add_item   (stringset_t *self, const gchar *item);
+bool          stringset_remove_item(stringset_t *self, const gchar *item);
+bool          stringset_clear      (stringset_t *self);
+GVariant     *stringset_to_variant (const stringset_t *self);
+gchar        *stringset_to_string  (const stringset_t *self);
+gchar       **stringset_to_strv    (const stringset_t *self);
+stringset_t  *stringset_from_strv  (char **vector);
+stringset_t  *stringset_copy       (const stringset_t *self);
+void          stringset_swap       (stringset_t *self, stringset_t *that);
+stringset_t  *stringset_filter_out (const stringset_t *self, const stringset_t *mask);
+stringset_t  *stringset_filter_in  (const stringset_t *self, const stringset_t *mask);
+bool          stringset_equal      (const stringset_t *self, const stringset_t *that);
+bool          stringset_extend     (stringset_t *self, const stringset_t *that);
+bool          stringset_assign     (stringset_t *self, const stringset_t *that);
+
+/* ========================================================================= *
+ * STRINGSET
+ * ========================================================================= */
+
+struct stringset_t
+{
+    /* GQueue keeps the set in deterministic order */
+    GQueue      sst_list;
+
+    /* GHashTable is used for lookups and memory management */
+    GHashTable *sst_hash;
+};
+
+static void
+stringset_ctor(stringset_t *self)
+{
+    //log_debug("stringset() create");
+    g_queue_init(&self->sst_list);
+    self->sst_hash = g_hash_table_new_full(g_str_hash, g_str_equal,
+                                           g_free, NULL);
+}
+
+static void
+stringset_dtor(stringset_t *self)
+{
+    //log_debug("stringset() delete");
+
+    stringset_clear(self);
+
+    if( self->sst_hash ) {
+        g_hash_table_unref(self->sst_hash),
+            self->sst_hash = NULL;
+    }
+}
+
+stringset_t *
+stringset_create(void)
+{
+    stringset_t *self = g_malloc0(sizeof *self);
+    stringset_ctor(self);
+    return self;
+}
+
+void
+stringset_delete(stringset_t *self)
+{
+    if( self ) {
+        stringset_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+stringset_delete_at(stringset_t **pself)
+{
+    stringset_delete(*pself), *pself = NULL;
+}
+
+void
+stringset_delete_cb(void *self)
+{
+    stringset_delete(self);
+}
+
+guint
+stringset_size(const stringset_t *self)
+{
+    return self->sst_list.length;
+}
+
+bool
+stringset_empty(const stringset_t *self)
+{
+    return stringset_size(self) == 0;
+}
+
+const GList *
+stringset_list(const stringset_t *self)
+{
+    return self->sst_list.head;
+}
+
+bool
+stringset_has_item(const stringset_t *self, const gchar *item)
+{
+    return g_hash_table_lookup(self->sst_hash, item) != 0;
+}
+
+bool
+stringset_add_item(stringset_t *self, const gchar *item)
+{
+    bool added_item = false;
+    const gchar *have = g_hash_table_lookup(self->sst_hash, item);
+    if( !have ) {
+        gchar *add = g_strdup(item);
+        g_hash_table_add(self->sst_hash, add);
+        g_queue_push_tail(&self->sst_list, add);
+        added_item = true;
+    }
+    return added_item;
+}
+
+bool
+stringset_remove_item(stringset_t *self, const gchar *item)
+{
+    bool removed_item = false;
+
+    const gchar *have = g_hash_table_lookup(self->sst_hash, item);
+    if( have ) {
+        g_queue_remove(&self->sst_list, have);
+        g_hash_table_remove(self->sst_hash, have);
+        removed_item = true;
+    }
+    return removed_item;
+}
+
+bool
+stringset_clear(stringset_t *self)
+{
+    bool removed_items = false;
+
+    if( !stringset_empty(self) ) {
+        g_queue_clear(&self->sst_list);
+        g_hash_table_remove_all(self->sst_hash);
+        removed_items = true;
+    }
+    return removed_items;
+}
+
+GVariant *
+stringset_to_variant(const stringset_t *self)
+{
+    GVariantBuilder *builder = g_variant_builder_new(G_VARIANT_TYPE("as"));
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next ) {
+        gchar *item = iter->data;
+        g_variant_builder_add(builder, "s", item);
+    }
+    GVariant *variant = g_variant_builder_end(builder);
+    g_variant_builder_unref(builder);
+    return variant;
+}
+
+gchar *
+stringset_to_string(const stringset_t *self)
+{
+    GString *string = g_string_new(NULL);
+    const gchar *sep = 0;
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next ) {
+        gchar *item = iter->data;
+        if( sep )
+            g_string_append(string, sep);
+        else
+            sep = ",";
+        g_string_append(string, item);
+    }
+    return g_string_free(string, false);
+}
+
+gchar **
+stringset_to_strv(const stringset_t *self)
+{
+    guint   count  = stringset_size(self) + 1;
+    gchar **vector = g_malloc0_n(count, sizeof *vector);
+    guint index = 0;
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next )
+        vector[index++] = g_strdup(iter->data);
+    vector[index++] = NULL;
+    return vector;
+}
+
+stringset_t *
+stringset_from_strv(char **vector)
+{
+    stringset_t *self = stringset_create();
+    if( vector ) {
+        for( size_t i = 0; vector[i]; ++i ) {
+            stringset_add_item(self, vector[i]);
+        }
+    }
+    return self;
+}
+
+stringset_t *
+stringset_copy(const stringset_t *self)
+{
+    stringset_t *copied = stringset_create();
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next ) {
+        gchar *item = iter->data;
+        stringset_add_item(copied, item);
+    }
+    return copied;
+}
+
+void
+stringset_swap(stringset_t *self, stringset_t *that)
+{
+    stringset_t temp = *self; *self = *that; *that = temp;
+}
+
+stringset_t *
+stringset_filter_out(const stringset_t *self, const stringset_t *mask)
+{
+    stringset_t *filtered = stringset_create();
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next ) {
+        gchar *item = iter->data;
+        if( !stringset_has_item(mask, item) )
+            stringset_add_item(filtered, item);
+    }
+    return filtered;
+}
+
+stringset_t *
+stringset_filter_in(const stringset_t *self, const stringset_t *mask)
+{
+    stringset_t *filtered = stringset_create();
+    for( const GList *iter = stringset_list(self); iter; iter = iter->next ) {
+        gchar *item = iter->data;
+        if( stringset_has_item(mask, item) )
+            stringset_add_item(filtered, item);
+    }
+    return filtered;
+}
+
+bool
+stringset_equal(const stringset_t *self, const stringset_t *that)
+{
+    bool equal = false;
+    if( stringset_size(self) == stringset_size(that) ) {
+        const GList *iter1 = stringset_list(self);
+        const GList *iter2 = stringset_list(that);
+        while( iter1 && iter2 ) {
+            if( g_strcmp0(iter1->data, iter2->data) ) {
+                break;
+            }
+            iter1 = iter1->next;
+            iter2 = iter2->next;
+        }
+        equal = !iter1 && !iter2;
+    }
+    return equal;
+}
+
+bool
+stringset_extend(stringset_t *self, const stringset_t *that)
+{
+    bool changed = false;
+    for( const GList *iter = stringset_list(that); iter; iter = iter->next ) {
+        if( stringset_add_item(self, iter->data) )
+            changed = true;
+    }
+    return changed;
+}
+
+bool
+stringset_assign(stringset_t *self, const stringset_t *that)
+{
+    bool changed = false;
+    if( !stringset_equal(self, that) ) {
+        stringset_clear(self);
+        stringset_extend(self, that);
+        changed = true;
+    }
+    return changed;
+}

--- a/daemon/stringset.h
+++ b/daemon/stringset.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  STRINGSET_H_
+# define STRINGSET_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct stringset_t stringset_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+stringset_t  *stringset_create     (void);
+void          stringset_delete     (stringset_t *self);
+void          stringset_delete_at  (stringset_t **pself);
+void          stringset_delete_cb  (void *self);
+guint         stringset_size       (const stringset_t *self);
+bool          stringset_empty      (const stringset_t *self);
+const GList  *stringset_list       (const stringset_t *self);
+bool          stringset_has_item   (const stringset_t *self, const gchar *item);
+bool          stringset_add_item   (stringset_t *self, const gchar *item);
+bool          stringset_remove_item(stringset_t *self, const gchar *item);
+bool          stringset_clear      (stringset_t *self);
+GVariant     *stringset_to_variant (const stringset_t *self);
+gchar        *stringset_to_string  (const stringset_t *self);
+gchar       **stringset_to_strv    (const stringset_t *self);
+stringset_t  *stringset_from_strv  (char **vector);
+stringset_t  *stringset_copy       (const stringset_t *self);
+void          stringset_swap       (stringset_t *self, stringset_t *that);
+stringset_t  *stringset_filter_out (const stringset_t *self, const stringset_t *mask);
+stringset_t  *stringset_filter_in  (const stringset_t *self, const stringset_t *mask);
+bool          stringset_equal      (const stringset_t *self, const stringset_t *that);
+bool          stringset_extend     (stringset_t *self, const stringset_t *that);
+bool          stringset_assign     (stringset_t *self, const stringset_t *that);
+
+G_END_DECLS
+
+#endif /* STRINGSET_H_ */

--- a/daemon/systemd/sailjaild.service
+++ b/daemon/systemd/sailjaild.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Application Permission Management Daemon
+Requires=dbus.service
+After=dbus.socket
+RequiresMountsFor=/home
+
+[Service]
+Type=notify
+ExecStart=/usr/bin/sailjaild --systemd
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/daemon/users.c
+++ b/daemon/users.c
@@ -1,0 +1,377 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "users.h"
+
+#include "logging.h"
+#include "util.h"
+#include "control.h"
+
+#include <pwd.h>
+#include <fnmatch.h>
+
+#include <gio/gio.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+#define USERS_UID_MIN 100000
+#define USERS_UID_MAX 100007
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * USERS
+ * ------------------------------------------------------------------------- */
+
+static void  users_ctor     (users_t *self, control_t *control);
+static void  users_dtor     (users_t *self);
+users_t     *users_create   (control_t *control);
+void         users_delete   (users_t *self);
+void         users_delete_at(users_t **pself);
+void         users_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_ATTRIBUTES
+ * ------------------------------------------------------------------------- */
+
+static control_t *users_control(const users_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_USER
+ * ------------------------------------------------------------------------- */
+
+uid_t users_first_user (const users_t *self);
+uid_t users_last_user  (const users_t *self);
+bool  users_user_exists(users_t *self, uid_t uid);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_NOTIFY
+ * ------------------------------------------------------------------------- */
+
+static void users_notify_changed(users_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_SCAN
+ * ------------------------------------------------------------------------- */
+
+static bool     users_scan_now     (users_t *self);
+static gboolean users_rescan_cb    (gpointer aptr);
+static void     users_rescan_later (users_t *self);
+static bool     users_cancel_rescan(users_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_MONITOR
+ * ------------------------------------------------------------------------- */
+
+static void users_start_monitor(users_t *self);
+static void users_stop_monitor (users_t *self);
+static bool users_monitor_p    (const gchar *path);
+static void users_monitor_cb   (GFileMonitor *mon, GFile *file1, GFile *file2, GFileMonitorEvent event, gpointer aptr);
+
+/* ========================================================================= *
+ * USERS
+ * ========================================================================= */
+
+struct users_t
+{
+    bool              usr_initialized;
+    control_t        *usr_control;
+    GHashTable       *usr_current;
+    guint             usr_rescan_id;
+    GFileMonitor     *usr_monitor_obj;
+};
+
+static void
+users_ctor(users_t *self, control_t *control)
+{
+    log_info("users() create");
+
+    self->usr_initialized = false;
+    self->usr_control     = control;
+    self->usr_current     = g_hash_table_new (g_direct_hash, g_direct_equal);
+    self->usr_rescan_id   = 0;
+    self->usr_monitor_obj = NULL;
+
+    /* Get initial state */
+    users_start_monitor(self);
+    users_scan_now(self);
+
+    /* Enable notifications */
+    self->usr_initialized = true;
+}
+
+static  void
+users_dtor(users_t *self)
+{
+    log_info("users() delete");
+
+    /* Disable notifications */
+    self->usr_initialized = true;
+
+    if( self->usr_current ) {
+        g_hash_table_unref(self->usr_current),
+            self->usr_current = NULL;
+    }
+
+    users_stop_monitor(self);
+    users_cancel_rescan(self);
+}
+
+users_t *
+users_create(control_t *control)
+{
+    users_t *self = g_malloc0(sizeof *self);
+    users_ctor(self, control);
+    return self;
+}
+
+void
+users_delete(users_t *self)
+{
+    if( self ) {
+        users_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+users_delete_at(users_t **pself)
+{
+    users_delete(*pself), *pself = NULL;
+}
+
+void
+users_delete_cb(void *self)
+{
+    users_delete(self);
+}
+
+/* ========================================================================= *
+ * USERS_ATTRIBUTES
+ * ========================================================================= */
+
+static control_t *
+users_control(const users_t *self)
+{
+    return self->usr_control;
+}
+
+/* ========================================================================= *
+ * USERS_USER
+ * ========================================================================= */
+
+uid_t
+users_first_user(const users_t *self)
+{
+    return USERS_UID_MIN;
+}
+
+uid_t
+users_last_user(const users_t *self)
+{
+    return USERS_UID_MAX;
+}
+
+bool
+users_user_exists(users_t *self, uid_t uid)
+{
+    if( users_cancel_rescan(self) )
+        users_scan_now(self);
+
+    return g_hash_table_contains(self->usr_current, GINT_TO_POINTER(uid));
+}
+
+/* ========================================================================= *
+ * USERS_NOTIFY
+ * ========================================================================= */
+
+static void
+users_notify_changed(users_t *self)
+{
+    if( self->usr_initialized ) {
+        log_info("USERS NOTIFY");
+        control_on_users_changed(users_control(self));
+    }
+}
+
+/* ========================================================================= *
+ * USERS_SCAN
+ * ========================================================================= */
+
+static bool
+users_scan_now(users_t *self)
+{
+    users_cancel_rescan(self);
+    log_info("USERS RESCAN: executing");
+
+    bool changed = false;
+    struct passwd *pw;
+
+    GHashTable *scanned = g_hash_table_new (g_direct_hash, g_direct_equal);
+
+    setpwent();
+    while( (pw = getpwent()) ) {
+        if( pw->pw_uid >= USERS_UID_MIN && pw->pw_uid <= USERS_UID_MAX ) {
+            g_hash_table_add(scanned, GINT_TO_POINTER(pw->pw_uid));
+        }
+    }
+    endpwent();
+
+    GHashTableIter iter;
+    gpointer key, value;
+    g_hash_table_iter_init(&iter, scanned);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        if( !g_hash_table_contains(self->usr_current, key) ) {
+            log_info("UID(%u) added", GPOINTER_TO_UINT(key));
+            changed = true;
+        }
+    }
+    g_hash_table_iter_init(&iter, self->usr_current);
+    while( g_hash_table_iter_next(&iter, &key, &value) ) {
+        if( !g_hash_table_contains(scanned, key) ) {
+            log_info("UID(%u) removed", GPOINTER_TO_UINT(key));
+            changed = true;
+        }
+    }
+
+    g_hash_table_unref(self->usr_current),
+        self->usr_current = scanned;
+
+    return changed;
+}
+
+static gboolean
+users_rescan_cb(gpointer aptr)
+{
+    users_t *self = aptr;
+
+    self->usr_rescan_id = 0;
+
+    log_info("USERS RESCAN: triggered");
+    if( users_scan_now(self) )
+        users_notify_changed(self);
+
+    return G_SOURCE_REMOVE;
+}
+
+static void
+users_rescan_later(users_t *self)
+{
+    if( self->usr_rescan_id )
+        g_source_remove(self->usr_rescan_id);
+    else
+        log_info("USERS RESCAN: scheduled");
+    self->usr_rescan_id = g_timeout_add(2500, users_rescan_cb, self);
+}
+
+static bool
+users_cancel_rescan(users_t *self)
+{
+    bool canceled = false;
+    if( self->usr_rescan_id ) {
+        log_info("USERS RESCAN: canceled");
+        g_source_remove(self->usr_rescan_id),
+            self->usr_rescan_id = 0;
+        canceled = true;
+    }
+    return canceled;
+}
+
+/* ========================================================================= *
+ * USERS_MONITOR
+ * ========================================================================= */
+
+static void
+users_start_monitor(users_t *self)
+{
+    users_stop_monitor(self);
+
+    GFileMonitorFlags flags = G_FILE_MONITOR_WATCH_MOVES;
+    GFile *file = g_file_new_for_path(USERS_DIRECTORY);
+    if( file ) {
+        if( (self->usr_monitor_obj = g_file_monitor_directory(file, flags, 0, 0)) ) {
+            g_signal_connect(self->usr_monitor_obj, "changed",
+                             G_CALLBACK(users_monitor_cb), self);
+            log_info("USERS MONITOR: started");
+        }
+        g_object_unref(file);
+    }
+}
+
+static void
+users_stop_monitor(users_t *self)
+{
+    if( self->usr_monitor_obj ) {
+        log_info("USERS MONITOR: stopped");
+        g_object_unref(self->usr_monitor_obj),
+            self->usr_monitor_obj = NULL;
+    }
+}
+
+static bool
+users_monitor_p(const gchar *path)
+{
+    path = path_basename(path);
+    return path && fnmatch(USERS_PATTERN, path, FNM_PATHNAME) == 0;
+}
+
+static void
+users_monitor_cb(GFileMonitor      *mon,
+                 GFile             *file1,
+                 GFile             *file2,
+                 GFileMonitorEvent  event,
+                 gpointer           aptr)
+{
+    users_t *self = aptr;
+
+    const char *path1 = file1 ? g_file_peek_path(file1) : NULL;
+    const char *path2 = file2 ? g_file_peek_path(file2) : NULL;
+    bool trigger = (users_monitor_p(path1) ||
+                    users_monitor_p(path2));
+
+    if( trigger ) {
+        log_info("USERS MONITOR: triggers @ %s %s", path1, path2);
+        users_rescan_later(self);
+    }
+}

--- a/daemon/users.h
+++ b/daemon/users.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  USERS_H_
+# define USERS_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct control_t control_t;
+typedef struct config_t  config_t;
+typedef struct users_t   users_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * USERS
+ * ------------------------------------------------------------------------- */
+
+users_t *users_create   (control_t *control);
+void     users_delete   (users_t *self);
+void     users_delete_at(users_t **pself);
+void     users_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * USERS_USER
+ * ------------------------------------------------------------------------- */
+
+uid_t users_first_user (const users_t *self);
+uid_t users_last_user  (const users_t *self);
+bool  users_user_exists(users_t *self, uid_t uid);
+
+G_END_DECLS
+
+#endif /* USERS_H_ */

--- a/daemon/util.c
+++ b/daemon/util.c
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "util.h"
+
+#include "logging.h"
+#include "stringset.h"
+
+#include <ctype.h>
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+char *strip(char *str);
+
+/* ------------------------------------------------------------------------- *
+ * PATH
+ * ------------------------------------------------------------------------- */
+
+const gchar  *path_basename            (const gchar *path);
+const gchar  *path_extension           (const gchar *path);
+gchar        *path_dirname             (const gchar *path);
+static gchar *path_stemname            (const gchar *path, const char *ext_to_remove);
+gchar        *path_to_desktop_name     (const gchar *path);
+gchar        *path_from_desktop_name   (const gchar *stem);
+gchar        *path_to_permission_name  (const gchar *path);
+gchar        *path_from_permission_name(const gchar *stem);
+
+/* ------------------------------------------------------------------------- *
+ * GUTIL
+ * ------------------------------------------------------------------------- */
+
+guint gutil_add_watch(int fd, GIOCondition cnd, GIOFunc cb, gpointer aptr);
+
+/* ------------------------------------------------------------------------- *
+ * CHANGE
+ * ------------------------------------------------------------------------- */
+
+bool change_uid         (uid_t *where, uid_t val);
+bool change_boolean     (bool *where, bool val);
+bool change_string      (gchar **pstr, const gchar *val);
+bool change_string_steal(gchar **pstr, gchar *val);
+
+/* ------------------------------------------------------------------------- *
+ * KEYFILE
+ * ------------------------------------------------------------------------- */
+
+bool         keyfile_save         (GKeyFile *file, const gchar *path);
+bool         keyfile_load         (GKeyFile *file, const gchar *path);
+void         keyfile_merge        (GKeyFile *file, const gchar *path);
+bool         keyfile_get_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool def);
+gint         keyfile_get_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint def);
+gchar       *keyfile_get_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *def);
+stringset_t *keyfile_get_stringset(GKeyFile *file, const gchar *sec, const gchar *key);
+void         keyfile_set_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool val);
+void         keyfile_set_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint val);
+void         keyfile_set_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *val);
+void         keyfile_set_stringset(GKeyFile *file, const gchar *sec, const gchar *key, const stringset_t *val);
+
+/* ========================================================================= *
+ * UTILITY
+ * ========================================================================= */
+
+char *
+strip(char *str)
+{
+    if( str ) {
+        char *src = str;
+        char *dst = str;
+        while( *src && isspace(*src) )
+            ++src;
+        for( ;; ) {
+            while( *src && !isspace(*src) )
+                *dst++ = *src++;
+            while( *src && isspace(*src) )
+                ++src;
+            if( !*src )
+                break;
+            *dst++ = ' ';
+        }
+    }
+    return str;
+}
+
+/* ========================================================================= *
+ * PATH
+ * ========================================================================= */
+
+const gchar *
+path_basename(const gchar *path)
+{
+    const gchar *base = NULL;
+    if( path ) {
+        gchar *end = strrchr(path, '/');
+        base = end ? end + 1 : path;
+    }
+    return base;
+}
+
+const gchar *
+path_extension(const gchar *path)
+{
+    const gchar *ext  = NULL;
+    const gchar *base = path_basename(path);
+    if( base )
+        ext = strrchr(base, '.');
+    return ext;
+}
+
+gchar *
+path_dirname(const gchar *path)
+{
+    gchar *dirp = NULL;
+    if( path )
+        dirp = g_path_get_dirname(path);
+    return dirp;
+}
+
+static gchar *
+path_stemname(const gchar *path, const char *ext_to_remove)
+{
+    gchar       *stem = NULL;
+    const gchar *base = path_basename(path);
+    if( base ) {
+        const gchar *end = path_extension(base);
+        if( !end || g_strcmp0(end, ext_to_remove) )
+            end = strchr(base, 0);
+        stem = g_strndup(base, end - base);
+    }
+    return stem;
+}
+
+gchar *
+path_to_desktop_name(const gchar *path)
+{
+    return path_stemname(path, APPLICATIONS_EXTENSION);
+}
+
+gchar *
+path_from_desktop_name(const gchar *stem)
+{
+    gchar *path = 0;
+    gchar *norm = path_to_desktop_name(stem);
+    if( norm )
+        path = g_strdup_printf(APPLICATIONS_DIRECTORY "/"
+                               "%s" APPLICATIONS_EXTENSION,
+                               norm);
+    g_free(norm);
+    return path;
+}
+
+gchar *
+path_to_permission_name(const gchar *path)
+{
+    return path_stemname(path, PERMISSIONS_EXTENSION);
+}
+
+gchar *
+path_from_permission_name(const gchar *stem)
+{
+    gchar *path = 0;
+    gchar *norm = path_to_permission_name(stem);
+    if( norm )
+        path = g_strdup_printf(PERMISSIONS_DIRECTORY "/"
+                               "%s" PERMISSIONS_EXTENSION,
+                               norm);
+    g_free(norm);
+    return path;
+}
+
+/* ========================================================================= *
+ * GUTIL
+ * ========================================================================= */
+
+guint
+gutil_add_watch(int fd, GIOCondition cnd, GIOFunc cb, gpointer aptr)
+{
+    guint       id  = 0;
+    GIOChannel *chn = 0;
+
+    cnd |= G_IO_ERR | G_IO_HUP | G_IO_NVAL;
+
+    if( !(chn = g_io_channel_unix_new(fd)) )
+        goto EXIT;
+
+    id = g_io_add_watch(chn, cnd, cb, aptr);
+
+EXIT:
+    if( chn != 0 )
+        g_io_channel_unref(chn);
+
+    return id;
+}
+
+/* ========================================================================= *
+ * CHANGE
+ * ========================================================================= */
+
+bool
+change_uid(uid_t *where, uid_t val)
+{
+    bool changed = false;
+    if( *where != val ) {
+        *where = val;
+        changed = true;
+    }
+    return changed;
+}
+
+bool
+change_boolean(bool *where, bool val)
+{
+    bool changed = false;
+    if( *where != val ) {
+        *where = val;
+        changed = true;
+    }
+    return changed;
+}
+
+bool
+change_string(gchar **pstr, const gchar *val)
+{
+    bool changed = false;
+    if( g_strcmp0(*pstr, val) ) {
+        g_free(*pstr), *pstr = g_strdup(val);
+        changed = true;
+    }
+    return changed;
+}
+
+bool
+change_string_steal(gchar **pstr, gchar *val)
+{
+    bool changed = false;
+    if( g_strcmp0(*pstr, val) ) {
+        g_free(*pstr), *pstr = val;
+        changed = true;
+    }
+    else if( *pstr != val ) {
+        g_free(val);
+    }
+    return changed;
+}
+
+/* ========================================================================= *
+ * KEYFILE
+ * ========================================================================= */
+
+bool
+keyfile_save(GKeyFile *file, const gchar *path)
+{
+    GError *err = NULL;
+    bool    ack = g_key_file_save_to_file(file, path, &err);
+    if( !ack )
+        log_err("%s: save failed: %s", path, err->message);
+    else
+        log_info("%s: saved succesfully", path);
+    g_clear_error(&err);
+    return ack;
+}
+
+bool
+keyfile_load(GKeyFile *file, const gchar *path)
+{
+    GError *err = NULL;
+    bool    ack = g_key_file_load_from_file(file, path, G_KEY_FILE_NONE, &err);
+
+    if( ack )
+        log_debug("%s: loaded succesfully", path);
+    else if( g_error_matches(err, G_FILE_ERROR, G_FILE_ERROR_NOENT) )
+        log_debug("%s: load failed: %s", path, err->message);
+    else
+        log_err("%s: load failed: %s", path, err->message);
+
+    g_clear_error(&err);
+    return ack;
+}
+
+void
+keyfile_merge(GKeyFile *file, const gchar *path)
+{
+    GKeyFile  *tmp = g_key_file_new();
+
+    if( !keyfile_load(tmp, path) )
+        goto EXIT;
+
+    gchar **groups = g_key_file_get_groups(tmp, NULL);
+    if( groups ) {
+        for( size_t i = 0; groups[i]; ++i ) {
+            gchar **keys = g_key_file_get_keys(tmp, groups[i], NULL, NULL);
+            if( keys ) {
+                for( size_t j = 0; keys[j]; ++j ) {
+                    gchar *val = g_key_file_get_value(tmp, groups[i],
+                                                      keys[j], NULL);
+                    if( val ) {
+                        g_key_file_set_value(file, groups[i], keys[j], val);
+                        log_debug("%s [%s] %s = %s\n", path, groups[i], keys[j],
+                                  strip(val));
+                        g_free(val);
+                    }
+                }
+                g_strfreev(keys);
+            }
+        }
+        g_strfreev(groups);
+    }
+EXIT:
+    if( tmp )
+        g_key_file_unref(tmp);
+}
+
+bool
+keyfile_get_boolean(GKeyFile *file, const gchar *sec, const gchar *key,
+                    bool def)
+{
+    GError *err = 0;
+    bool    val = g_key_file_get_boolean(file, sec, key, &err);
+    if( err )
+        val = def;
+    g_clear_error(&err);
+    return val;
+}
+
+gint
+keyfile_get_integer(GKeyFile *file, const gchar *sec, const gchar *key,
+                    gint def)
+{
+    GError *err = 0;
+    gint    val = g_key_file_get_integer(file, sec, key, &err);
+    if( err )
+        val = def;
+    g_clear_error(&err);
+    return val;
+}
+
+gchar *
+keyfile_get_string(GKeyFile *file, const gchar *sec, const gchar *key,
+                   const gchar *def)
+{
+    gchar *val = g_key_file_get_string(file, sec, key, NULL);
+    if( !val )
+        val = g_strdup(def);
+    return val;
+}
+
+stringset_t *
+keyfile_get_stringset(GKeyFile *file, const gchar *sec, const gchar *key)
+{
+    stringset_t *val = stringset_create();
+
+    gchar **vec = g_key_file_get_string_list(file, sec, key, NULL, NULL);
+    if( vec ) {
+        for( size_t i = 0; vec[i]; ++i )
+            stringset_add_item(val, vec[i]);
+        g_strfreev(vec);
+    }
+    return val;
+}
+
+void
+keyfile_set_boolean(GKeyFile *file, const gchar *sec, const gchar *key,
+                    bool val)
+{
+    g_key_file_set_boolean(file, sec, key, val);
+}
+
+void
+keyfile_set_integer(GKeyFile *file, const gchar *sec, const gchar *key,
+                    gint val)
+{
+    g_key_file_set_integer(file, sec, key, val);
+}
+
+void
+keyfile_set_string(GKeyFile *file, const gchar *sec, const gchar *key,
+                   const gchar *val)
+{
+    g_key_file_set_string(file, sec, key, val ?: "");
+}
+
+void
+keyfile_set_stringset(GKeyFile *file, const gchar *sec, const gchar *key,
+                      const stringset_t *val)
+{
+    /* An interesting twist: g_key_file_set_string_list()
+     * does not support zero length lists...
+     */
+
+    gchar **vec = stringset_to_strv(val);
+    gsize len = 0;
+    if( vec )
+        while( vec[len] )
+            ++len;
+    if( len > 0 )
+        g_key_file_set_string_list(file, sec, key, (const gchar * const *)vec, len);
+    else
+        g_key_file_set_string(file, sec, key, "");
+    g_strfreev(vec);
+}

--- a/daemon/util.h
+++ b/daemon/util.h
@@ -1,0 +1,173 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#ifndef  UTIL_H_
+# define UTIL_H_
+
+# include <stdbool.h>
+# include <glib.h>
+
+G_BEGIN_DECLS
+
+/* ========================================================================= *
+ * Constants
+ * ========================================================================= */
+
+/* Expected: We get these from Makefile, or spec during rpm build */
+# ifndef  VERSION
+#  define VERSION                       "0.0.0"
+# endif
+
+# ifndef  SYSCONFDIR
+#  define SYSCONFDIR                    "/etc"
+# endif
+
+# ifndef  SHAREDSTATEDIR
+#  define SHAREDSTATEDIR                "/var/lib"
+# endif
+
+# ifndef  DATADIR
+#  define DATADIR                       "/usr/share"
+# endif
+
+/* Config from: *.conf */
+# define CONFIG_DIRECTORY               SYSCONFDIR "/sailjail/config"
+# define CONFIG_EXTENSION               ".conf"
+# define CONFIG_PATTERN                 "[0-9][0-9]*" CONFIG_EXTENSION
+
+/* Users from: passwd */
+# define USERS_DIRECTORY                SYSCONFDIR
+# define USERS_EXTENSION                ""
+# define USERS_PATTERN                  "passwd" USERS_EXTENSION
+
+/* Permissions from: *.permission */
+# define PERMISSIONS_DIRECTORY          SYSCONFDIR "/sailjail/permissions"
+# define PERMISSIONS_EXTENSION          ".permission"
+# define PERMISSIONS_PATTERN            "[A-Z]*" PERMISSIONS_EXTENSION
+
+/* Applications  from: *.desktop */
+# define APPLICATIONS_DIRECTORY         DATADIR "/applications"
+# define APPLICATIONS_EXTENSION         ".desktop"
+# define APPLICATIONS_PATTERN           "*" APPLICATIONS_EXTENSION
+
+/* Settings from: *.settings */
+# define SETTINGS_DIRECTORY             SHAREDSTATEDIR "/sailjail/settings"
+# define SETTINGS_EXTENSION             ".settings"
+# define SETTINGS_PATTERN               "*" SETTINGS_EXTENSION
+
+/* Standard desktop properties */
+# define DESKTOP_SECTION                "Desktop Entry"
+# define DESKTOP_KEY_NAME               "Name"
+# define DESKTOP_KEY_TYPE               "Type"
+# define DESKTOP_KEY_ICON               "Icon"
+# define DESKTOP_KEY_EXEC               "Exec"
+# define DESKTOP_KEY_NO_DISPLAY         "NoDisplay"
+
+/* Maemo desktop properties */
+# define MAEMO_SECTION                  "Desktop Entry"
+# define MAEMO_KEY_SERVICE              "X-Maemo-Service"
+# define MAEMO_KEY_OBJECT               "X-Maemo-Object-Path"
+# define MAEMO_KEY_METHOD               "X-Maemo-Method"
+
+/* Sailjail desktop properties */
+# define SAILJAIL_SECTION_PRIMARY       "X-Sailjail"
+# define SAILJAIL_SECTION_SECONDARY     "Sailjail"
+# define SAILJAIL_KEY_ORGANIZATION_NAME "OrganizationName"
+# define SAILJAIL_KEY_APPLICATION_NAME  "ApplicationName"
+# define SAILJAIL_KEY_PERMISSIONS       "Permissions"
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct stringset_t    stringset_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+char *strip(char *str);
+
+/* ------------------------------------------------------------------------- *
+ * PATH
+ * ------------------------------------------------------------------------- */
+
+const gchar *path_basename            (const gchar *path);
+const gchar *path_extension           (const gchar *path);
+gchar       *path_dirname             (const gchar *path);
+gchar       *path_to_desktop_name     (const gchar *path);
+gchar       *path_from_desktop_name   (const gchar *stem);
+gchar       *path_to_permission_name  (const gchar *path);
+gchar       *path_from_permission_name(const gchar *stem);
+
+/* ------------------------------------------------------------------------- *
+ * GUTIL
+ * ------------------------------------------------------------------------- */
+
+guint gutil_add_watch(int fd, GIOCondition cnd, GIOFunc cb, gpointer aptr);
+
+/* ------------------------------------------------------------------------- *
+ * CHANGE
+ * ------------------------------------------------------------------------- */
+
+bool change_uid         (uid_t *where, uid_t val);
+bool change_boolean     (bool *where, bool val);
+bool change_string      (gchar **pstr, const gchar *val);
+bool change_string_steal(gchar **pstr, gchar *val);
+
+/* ------------------------------------------------------------------------- *
+ * KEYFILE
+ * ------------------------------------------------------------------------- */
+
+bool         keyfile_save         (GKeyFile *file, const gchar *path);
+bool         keyfile_load         (GKeyFile *file, const gchar *path);
+void         keyfile_merge        (GKeyFile *file, const gchar *path);
+bool         keyfile_get_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool def);
+gint         keyfile_get_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint def);
+gchar       *keyfile_get_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *def);
+stringset_t *keyfile_get_stringset(GKeyFile *file, const gchar *sec, const gchar *key);
+void         keyfile_set_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool val);
+void         keyfile_set_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint val);
+void         keyfile_set_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *val);
+void         keyfile_set_stringset(GKeyFile *file, const gchar *sec, const gchar *key, const stringset_t *val);
+
+G_END_DECLS
+
+#endif /* UTIL_H_ */

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -24,6 +24,12 @@ Requires: libglibutil >= %{libglibutil_version}
 # libglibutil >= 1.0.49 is required for gutil_slice_free() macro
 BuildRequires: pkgconfig(libglibutil) >= 1.0.49
 BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}
+BuildRequires: pkgconfig(gobject-2.0)
+BuildRequires: pkgconfig(gio-2.0)
+BuildRequires: pkgconfig(libsystemd)
+
+# Keep settings in encrypted home partition
+%define _sharedstatedir /home/.system/var/lib
 
 %description
 Firejail-based sanboxing for Sailfish OS.
@@ -44,6 +50,15 @@ Requires: python3-base
 %{summary}.
 Contains a script to measure launching time.
 
+%package daemon
+Summary: Daemon for managing application sandboxing permissions
+
+%description daemon
+This package contains daemon that keeps track of:
+- defined permissions (under /etc/sailjail/permissions)
+- permissions required by applications (under /usr/share/applications)
+- what permissions user has granted to each application
+
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -54,12 +69,36 @@ make %{_smp_mflags} \
   HAVE_FIREJAIL=%{jailfish} \
   release pkgconfig
 
+make %{_smp_mflags} \
+  VERSION=%{version}\
+  _LIBDIR=%{_libdir}\
+  _SHAREDSTATEDIR=%{_sharedstatedir}\
+  -C daemon build
+
 %install
 rm -rf %{buildroot}
 make DESTDIR=%{buildroot} LIBDIR=%{_libdir} install install-dev
 
 install -D -m755 tools/measure_launch_time.py \
         %{buildroot}%{_bindir}/measure_launch_time
+
+make \
+  _SYSCONFDIR=%{_sysconfdir}\
+  _DATADIR=%{_datadir}\
+  _LIBDIR=%{_libdir}\
+  _USERUNITDIR=%{_userunitdir}\
+  _UNITDIR=%{_unitdir}\
+  _SHAREDSTATEDIR=%{_sharedstatedir}\
+  DESTDIR=%{buildroot}\
+  -C daemon install
+
+install -d %{buildroot}%{_unitdir}/multi-user.target.wants
+install -m644 daemon/systemd/sailjaild.service %{buildroot}%{_unitdir}
+ln -s ../sailjaild.service %{buildroot}%{_unitdir}/multi-user.target.wants/
+install -d %{buildroot}%{_sysconfdir}/dbus-1/system.d
+install -m644 daemon/dbus/sailjaild.conf %{buildroot}%{_sysconfdir}/dbus-1/system.d/sailjaild.conf
+install -d %{buildroot}%{_sharedstatedir}/sailjail/settings
+install -d %{buildroot}%{_sysconfdir}/sailjail/config
 
 %check
 make HAVE_FIREJAIL=%{jailfish} -C unit test
@@ -81,3 +120,14 @@ make HAVE_FIREJAIL=%{jailfish} -C unit test
 %files tools
 %defattr(-,root,root,-)
 %{_bindir}/measure_launch_time
+
+%files daemon
+%defattr(-,root,root,-)
+%license COPYING
+%{_bindir}/sailjaild
+%{_unitdir}/*.service
+%{_unitdir}/multi-user.target.wants/*.service
+%config %{_sysconfdir}/dbus-1/system.d/sailjaild.conf
+%attr(0755,root,root) %dir %ghost %{_sharedstatedir}/sailjail
+%attr(0750,root,root) %dir %ghost %{_sharedstatedir}/sailjail/settings
+%dir %{_sysconfdir}/sailjail/config


### PR DESCRIPTION
Daemon:
- Implementes D-Bus service in D-Bus Systembus
- Maintains persistent cache of user specific settings
- Monitors available applications, permissions, users and active user
  session

D-Bus service:
- Service name is: org.sailfishos.sailjaild1
- Object path is: /org/sailfishos/sailjaild1
- Interface is: org.sailfishos.sailjaild1
- Implemented methods are:
  - QStringList GetApplications()
  - QVariantMap GetAppInfo(QString application)
  - void SetGrantedPermissions(uint uid, QString application,
                               QStringList permissions)
  - QStringList GetGrantedPermissions(uint uid, QString application)
  - int GetLaunchAllowed(uint uid, QString application)
  - void SetLaunchAllowed(uint uid, QString application, int allowed)
  - QStringList QueryLaunchPermissions(QString application)
  - QStringList PromptLaunchPermissions(QString application)
- Emitted signals are:
  - void ApplicationAdded(QString application)
  - void ApplicationChanged(QString application)
  - void ApplicationRemoved(QString application)

Checking application launch permissions should be done
with QueryLaunchPermissions() or PromptLaunchPermissions().
The difference between these two is that the latter will
prompt user for acceptance if permissions have not yet
been granted. Checking is done in the context of currently
active user session.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>