### PR TITLE
Support org and app name with firejail templates

### DIFF
--- a/daemon/service.c
+++ b/daemon/service.c
@@ -46,6 +46,7 @@
 #include "session.h"
 #include "stringset.h"
 #include "settings.h"
+#include "util.h"
 
 #include <dbusaccess_peer.h>
 #include <dbusaccess_policy.h>

--- a/daemon/settings.c
+++ b/daemon/settings.c
@@ -45,6 +45,7 @@
 
 #include <errno.h>
 #include <unistd.h>
+#include <errno.h>
 
 /* ========================================================================= *
  * Config

--- a/include/jail_rules.h
+++ b/include/jail_rules.h
@@ -39,12 +39,20 @@
 
 #include "jail_types.h"
 
+#define SAILJAIL_KEY_ORGANIZATION_NAME "OrganizationName"
+#define SAILJAIL_KEY_APPLICATION_NAME "ApplicationName"
+
 G_BEGIN_DECLS
 
 typedef enum jail_permit_type {
     JAIL_PERMIT_INVALID,
     JAIL_PERMIT_PRIVILEGED
 } JAIL_PERMIT_TYPE;
+
+typedef enum jail_validate_str_type {
+    JAIL_VALIDATE_STR_COMMON = 0, /* 'A-Za-z0-9_' */
+    JAIL_VALIDATE_STR_ORG, /* COMMON + '.-' */
+} JAIL_VALIDATE_STR_TYPE;
 
 typedef struct jail_permit {
     gboolean require;
@@ -113,6 +121,11 @@ void
 jail_rules_unref(
     JailRules* rules)
     SAILJAIL_EXPORT;
+
+const char*
+jail_rules_get_value(
+    const JailRules* rules,
+    const char *key);
 
 /* Only leaves required and the specified optional items */
 JailRules*

--- a/src/jail_run.c
+++ b/src/jail_run.c
@@ -187,6 +187,22 @@ jail_run(
         g_ptr_array_add(args, (gpointer) FIREJAIL_DEBUG_OPT);
     }
 
+    const char *org_name = jail_rules_get_value(rules, SAILJAIL_KEY_ORGANIZATION_NAME);
+    if (org_name) {
+        char* opt = g_strconcat("--template=", SAILJAIL_KEY_ORGANIZATION_NAME,
+                                                        ":", org_name, NULL);
+        g_ptr_array_add(args, opt);
+        g_ptr_array_add(args_alloc, opt);
+    }
+
+    const char *app_name = jail_rules_get_value(rules, SAILJAIL_KEY_APPLICATION_NAME);
+    if (app_name) {
+        char* opt = g_strconcat("--template=", SAILJAIL_KEY_APPLICATION_NAME,
+                                                        ":", app_name, NULL);
+        g_ptr_array_add(args, opt);
+        g_ptr_array_add(args_alloc, opt);
+    }
+
     /* Profiles */
     for (pro_ptr = rules->profiles; *pro_ptr; pro_ptr++) {
         char* opt = g_strconcat(FIREJAIL_PROFILE_OPT, (*pro_ptr)->path, NULL);

--- a/src/jail_run.c
+++ b/src/jail_run.c
@@ -165,6 +165,7 @@ jail_run(
     GPtrArray* args_alloc = g_ptr_array_new(); /* Only the allocated ones */
     const JailDBus* dbus_user = rules->dbus_user;
     const JailDBus* dbus_system = rules->dbus_system;
+    gint dbus_system_filter_added = 0;
 
     g_ptr_array_set_free_func(args_alloc, g_free);
 
@@ -235,6 +236,7 @@ jail_run(
     if (jail_ptrv_length(dbus_system->own) ||
         jail_ptrv_length(dbus_system->talk)) {
         g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_SYSTEM_FILTER);
+        dbus_system_filter_added = 1;
         if (gutil_log_default.level > GLOG_LEVEL_DEBUG) {
             g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_SYSTEM_LOG);
         }
@@ -255,6 +257,8 @@ jail_run(
         opt = g_strdup_printf(FIREJAIL_DBUS_LOG_OPT_FMT, trace_dir);
         g_ptr_array_add(args, opt);
         g_ptr_array_add(args_alloc, opt);
+        if (!dbus_system_filter_added)
+            g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_SYSTEM_FILTER);
         g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_SYSTEM_LOG);
         g_ptr_array_add(args, (gpointer) FIREJAIL_DBUS_USER_LOG);
     }


### PR DESCRIPTION
Save the organization and application name when parsing the permission
file. Pass these as OrganizationName and ApplicationName key templates
to firejail to be utilized when using, e.g., ${ApplicationName} macro
on a D-Bus name ownership rule to allow owning an application specific
D-Bus name.

To not to break compatibility with plugin API move org and app name
variables to private rules and add a getter for these. Use the already
defined SAILJAIL_KEY_{APPLICATION,ORGANIZATION}_NAME as key values as
well to be consistent. Constify the arg for jail_rules_cast() -
apparently G_CAST approves const pointers as well.

Organization name can have 'A-Za-z0-9._-' characters and cannot start
with a digit, nor it can have two consecutive dots or dot followed with
a digit. Allow to use hyphen in the org name as rDNS spec allows it.
Since the template names can be used anywhere this restriction to follow
only D-Bus name spec is too restrictive..

Application name can have 'A-Za-z0-9_' characters and cannot start with
a digit.

If either, organization or application name fails the checks error
message is printed and sailjail quits.


