### PR TITLE
Remove state data when needed

### DIFF
--- a/daemon/control.c
+++ b/daemon/control.c
@@ -287,6 +287,11 @@ control_current_user(const control_t *self)
 bool
 control_valid_user(const control_t *self, uid_t uid)
 {
+    /* Guest user is considered invalid if it doesn't have an active
+     * user session.
+     */
+    if (control_user_is_guest(self, uid) && control_current_user(self) != uid)
+        return false;
     return users_user_exists(control_users(self), uid);
 }
 

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -337,6 +337,9 @@ control_on_users_changed(control_t *self)
                    (unsigned)uid,
                    users_user_exists(users, uid) ? "exists" : "n/a");
     }
+
+    later_schedule(self->ctl_rethink_settings);
+    // -> control_rethink_settings_cb()
 }
 
 void

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -85,6 +85,7 @@ uid_t              control_current_user          (const control_t *self);
 bool               control_valid_user            (const control_t *self, uid_t uid);
 uid_t              control_min_user              (const control_t *self);
 uid_t              control_max_user              (const control_t *self);
+bool               control_user_is_guest         (const control_t *self, uid_t uid);
 const stringset_t *control_available_permissions (const control_t *self);
 bool               control_valid_permission      (const control_t *self, const char *perm);
 const stringset_t *control_available_applications(const control_t *self);
@@ -293,6 +294,12 @@ uid_t
 control_max_user(const control_t *self)
 {
     return users_last_user(control_users(self));
+}
+
+bool
+control_user_is_guest(const control_t *self, uid_t uid)
+{
+    return users_user_is_guest(control_users(self), uid);
 }
 
 const stringset_t *

--- a/daemon/control.h
+++ b/daemon/control.h
@@ -88,6 +88,7 @@ uid_t              control_current_user          (const control_t *self);
 bool               control_valid_user            (const control_t *self, uid_t uid);
 uid_t              control_min_user              (const control_t *self);
 uid_t              control_max_user              (const control_t *self);
+bool               control_user_is_guest         (const control_t *self, uid_t uid);
 const stringset_t *control_available_permissions (const control_t *self);
 bool               control_valid_permission      (const control_t *self, const char *perm);
 const stringset_t *control_available_applications(const control_t *self);

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -697,7 +697,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
         const gchar *app = NULL;
         g_variant_get(parameters, "(u&s)", &uid, &app);
         appsettings_t *appsettings = NULL;
-        if( !control_valid_user(service_control(self), uid) ) {
+        if( control_user_is_guest(service_control(self), uid) &&
+            control_current_user(service_control(self)) != uid ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+        }
+        else if( !control_valid_user(service_control(self), uid) ) {
             error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
         }
         else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
@@ -719,7 +723,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
             gint        agreed = APP_AGREED_UNSET;
             g_variant_get(parameters, "(u&si)", &uid, &app, &agreed);
             appsettings_t *appsettings = NULL;
-            if( !control_valid_user(service_control(self), uid) ) {
+            if( control_user_is_guest(service_control(self), uid) &&
+                control_current_user(service_control(self)) != uid ) {
+                error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+            }
+            else if( !control_valid_user(service_control(self), uid) ) {
                 error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
             }
             else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
@@ -736,7 +744,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
         const gchar *app = NULL;
         g_variant_get(parameters, "(u&s)", &uid, &app);
         appsettings_t *appsettings = NULL;
-        if( !control_valid_user(service_control(self), uid) ) {
+        if( control_user_is_guest(service_control(self), uid) &&
+            control_current_user(service_control(self)) != uid ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+        }
+        else if( !control_valid_user(service_control(self), uid) ) {
             error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
         }
         else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
@@ -758,7 +770,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
             gint        allowed = APP_ALLOWED_UNSET;
             g_variant_get(parameters, "(u&si)", &uid, &app, &allowed);
             appsettings_t *appsettings = NULL;
-            if( !control_valid_user(service_control(self), uid) ) {
+            if( control_user_is_guest(service_control(self), uid) &&
+                control_current_user(service_control(self)) != uid ) {
+                error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+            }
+            else if( !control_valid_user(service_control(self), uid) ) {
                 error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
             }
             else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
@@ -775,7 +791,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
         const gchar *app = NULL;
         g_variant_get(parameters, "(u&s)", &uid, &app);
         appsettings_t *appsettings = NULL;
-        if( !control_valid_user(service_control(self), uid) ) {
+        if( control_user_is_guest(service_control(self), uid) &&
+            control_current_user(service_control(self)) != uid ) {
+            error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+        }
+        else if( !control_valid_user(service_control(self), uid) ) {
             error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
         }
         else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {
@@ -799,7 +819,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
             gchar **vector   = NULL;
             g_variant_get(parameters, "(u&s^as)", &uid, &app, &vector);
             appsettings_t *appsettings = NULL;
-            if( !control_valid_user(service_control(self), uid) ) {
+            if( control_user_is_guest(service_control(self), uid) &&
+                control_current_user(service_control(self)) != uid ) {
+                error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN);
+            }
+            else if( !control_valid_user(service_control(self), uid) ) {
                 error_reply(G_DBUS_ERROR_INVALID_ARGS, SERVICE_MESSAGE_INVALID_USER, uid);
             }
             else if( !(appsettings = control_appsettings(service_control(self), uid, app)) ) {

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -77,6 +77,7 @@ G_BEGIN_DECLS;
 # define SERVICE_MESSAGE_DENIED_PERMANENTLY    "Denied permanently"
 # define SERVICE_MESSAGE_NOT_ALLOWED           "Not allowed"
 # define SERVICE_MESSAGE_RESTRICTED_METHOD     "%s is not allowed to access %s"
+# define SERVICE_MESSAGE_GUEST_NOT_LOGGED_IN   "Guest user is not logged in"
 
 # define PERMISSIONMGR_NOTIFY_DELAY            0 // [ms]
 

--- a/daemon/users.c
+++ b/daemon/users.c
@@ -51,6 +51,7 @@
 
 #define USERS_UID_MIN 100000
 #define USERS_UID_MAX 100007
+#define USERS_UID_GUEST 105000
 
 /* ========================================================================= *
  * Types
@@ -84,6 +85,7 @@ static control_t *users_control(const users_t *self);
 uid_t users_first_user (const users_t *self);
 uid_t users_last_user  (const users_t *self);
 bool  users_user_exists(users_t *self, uid_t uid);
+bool  users_user_is_guest(const users_t *self, uid_t uid);
 
 /* ------------------------------------------------------------------------- *
  * USERS_NOTIFY
@@ -222,6 +224,13 @@ users_user_exists(users_t *self, uid_t uid)
     return g_hash_table_contains(self->usr_current, GINT_TO_POINTER(uid));
 }
 
+bool
+users_user_is_guest(const users_t *self, uid_t uid)
+{
+    (void)self; // unused
+    return uid == USERS_UID_GUEST;
+}
+
 /* ========================================================================= *
  * USERS_NOTIFY
  * ========================================================================= */
@@ -252,7 +261,8 @@ users_scan_now(users_t *self)
 
     setpwent();
     while( (pw = getpwent()) ) {
-        if( pw->pw_uid >= USERS_UID_MIN && pw->pw_uid <= USERS_UID_MAX ) {
+        if( (pw->pw_uid >= USERS_UID_MIN && pw->pw_uid <= USERS_UID_MAX) ||
+            pw->pw_uid == USERS_UID_GUEST ) {
             g_hash_table_add(scanned, GINT_TO_POINTER(pw->pw_uid));
         }
     }

--- a/daemon/users.h
+++ b/daemon/users.h
@@ -67,9 +67,10 @@ void     users_delete_cb(void *self);
  * USERS_USER
  * ------------------------------------------------------------------------- */
 
-uid_t users_first_user (const users_t *self);
-uid_t users_last_user  (const users_t *self);
-bool  users_user_exists(users_t *self, uid_t uid);
+uid_t users_first_user   (const users_t *self);
+uid_t users_last_user    (const users_t *self);
+bool  users_user_exists  (users_t *self, uid_t uid);
+bool  users_user_is_guest(const users_t *self, uid_t uid);
 
 G_END_DECLS
 


### PR DESCRIPTION
Remove state data when user or application is removed. Either it is
detected via inotify or it has happened when daemon wasn't running. If
user is removed or has been removed, their respecive data file is
removed and usersettings instance destroyed. If application profile is
removed or has been removed, then the appsettings instance is destroyed
and usersettings are saved again to remove stale data.

Support guest user properly by changing settings so that guest user
settings are not saved to disk and they are discarded after user session
ends. Also treat guest user as valid user in users.