### PR TITLE
Implement access control.

### DIFF
--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -95,6 +95,7 @@ PKG_NAMES += glib-2.0
 PKG_NAMES += gobject-2.0
 PKG_NAMES += gio-2.0
 PKG_NAMES += libsystemd
+PKG_NAMES += libdbusaccess
 
 maintenance  = normalize clean distclean mostlyclean
 intersection = $(strip $(foreach w,$1, $(filter $w,$2)))

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -450,9 +450,6 @@ service_is_nameowner(const service_t *self)
 static const gchar introspect_xml[] =\
 "<node>"
 "  <interface name='" PERMISSIONMGR_INTERFACE "'>"
-"    <method name='" PERMISSIONMGR_METHOD_QUIT "'>"
-"    </method>"
-
 "    <method name='" PERMISSIONMGR_METHOD_GET_APPLICATIONS "'>"
 "      <arg type='as' name='applications' direction='out'/>"
 "    </method>"
@@ -791,10 +788,6 @@ service_dbus_call_cb(GDBusConnection       *connection,
             }
             stringset_delete(filtered);
         }
-    }
-    else if( !g_strcmp0(method_name, PERMISSIONMGR_METHOD_QUIT) ) {
-        value_reply(NULL);
-        app_quit();
     }
     else {
         error_reply(G_DBUS_ERROR_UNKNOWN_METHOD, "Unknown method: %s",

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -76,6 +76,7 @@ G_BEGIN_DECLS;
 # define SERVICE_MESSAGE_INVALID_PERMISSIONS   "Invalid permissions list"
 # define SERVICE_MESSAGE_DENIED_PERMANENTLY    "Denied permanently"
 # define SERVICE_MESSAGE_NOT_ALLOWED           "Not allowed"
+# define SERVICE_MESSAGE_RESTRICTED_METHOD     "%s is not allowed to access %s"
 
 # define PERMISSIONMGR_NOTIFY_DELAY            0 // [ms]
 

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -56,7 +56,6 @@ G_BEGIN_DECLS;
 # define PERMISSIONMGR_SERVICE                 "org.sailfishos.sailjaild1"
 # define PERMISSIONMGR_INTERFACE               "org.sailfishos.sailjaild1"
 # define PERMISSIONMGR_OBJECT                  "/org/sailfishos/sailjaild1"
-# define PERMISSIONMGR_METHOD_QUIT             "Quit"
 # define PERMISSIONMGR_METHOD_PROMPT           "PromptLaunchPermissions"
 # define PERMISSIONMGR_METHOD_QUERY            "QueryLaunchPermissions"
 # define PERMISSIONMGR_METHOD_GET_APPLICATIONS "GetApplications"

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -27,6 +27,7 @@ BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}
 BuildRequires: pkgconfig(gobject-2.0)
 BuildRequires: pkgconfig(gio-2.0)
 BuildRequires: pkgconfig(libsystemd)
+BuildRequires: pkgconfig(libdbusaccess)
 
 # Keep settings in encrypted home partition
 %define _sharedstatedir /home/.system/var/lib


### PR DESCRIPTION
This implements access control for set methods using libdbusaccess. It's implemented using two hardcoded policies that allow root,
privileged and sailfish-mdm to access the methods. Although libdbusaccess allows to make more complex policy rules, I kept this
simple.

Also remove Quit() method from D-Bus interface. No need to add access control when it doesn't exist. It was only
temporary anyway.