### PR TITLE
Read both desktop file locations

### DIFF
--- a/daemon/util.c
+++ b/daemon/util.c
@@ -86,7 +86,7 @@ bool change_string_steal(gchar **pstr, gchar *val);
 
 bool         keyfile_save         (GKeyFile *file, const gchar *path);
 bool         keyfile_load         (GKeyFile *file, const gchar *path);
-void         keyfile_merge        (GKeyFile *file, const gchar *path);
+bool         keyfile_merge        (GKeyFile *file, const gchar *path);
 bool         keyfile_get_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool def);
 gint         keyfile_get_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint def);
 gchar       *keyfile_get_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *def);
@@ -329,12 +329,13 @@ keyfile_load(GKeyFile *file, const gchar *path)
     return ack;
 }
 
-void
+bool
 keyfile_merge(GKeyFile *file, const gchar *path)
 {
+    bool       ack = false;
     GKeyFile  *tmp = g_key_file_new();
 
-    if( !keyfile_load(tmp, path) )
+    if( !(ack = keyfile_load(tmp, path)) )
         goto EXIT;
 
     gchar **groups = g_key_file_get_groups(tmp, NULL);
@@ -360,6 +361,7 @@ keyfile_merge(GKeyFile *file, const gchar *path)
 EXIT:
     if( tmp )
         g_key_file_unref(tmp);
+    return ack;
 }
 
 bool

--- a/daemon/util.c
+++ b/daemon/util.c
@@ -55,14 +55,15 @@ char *strip(char *str);
  * PATH
  * ------------------------------------------------------------------------- */
 
-const gchar  *path_basename            (const gchar *path);
-const gchar  *path_extension           (const gchar *path);
-gchar        *path_dirname             (const gchar *path);
-static gchar *path_stemname            (const gchar *path, const char *ext_to_remove);
-gchar        *path_to_desktop_name     (const gchar *path);
-gchar        *path_from_desktop_name   (const gchar *stem);
-gchar        *path_to_permission_name  (const gchar *path);
-gchar        *path_from_permission_name(const gchar *stem);
+const gchar  *path_basename             (const gchar *path);
+const gchar  *path_extension            (const gchar *path);
+gchar        *path_dirname              (const gchar *path);
+static gchar *path_stemname             (const gchar *path, const char *ext_to_remove);
+gchar        *path_to_desktop_name      (const gchar *path);
+gchar        *path_from_desktop_name    (const gchar *stem);
+gchar        *alt_path_from_desktop_name(const gchar *stem);
+gchar        *path_to_permission_name   (const gchar *path);
+gchar        *path_from_permission_name (const gchar *stem);
 
 /* ------------------------------------------------------------------------- *
  * GUTIL
@@ -181,6 +182,19 @@ path_from_desktop_name(const gchar *stem)
     gchar *norm = path_to_desktop_name(stem);
     if( norm )
         path = g_strdup_printf(APPLICATIONS_DIRECTORY "/"
+                               "%s" APPLICATIONS_EXTENSION,
+                               norm);
+    g_free(norm);
+    return path;
+}
+
+gchar *
+alt_path_from_desktop_name(const gchar *stem)
+{
+    gchar *path = 0;
+    gchar *norm = path_to_desktop_name(stem);
+    if( norm )
+        path = g_strdup_printf(SAILJAIL_APP_DIRECTORY "/"
                                "%s" APPLICATIONS_EXTENSION,
                                norm);
     g_free(norm);

--- a/daemon/util.h
+++ b/daemon/util.h
@@ -78,10 +78,13 @@ G_BEGIN_DECLS
 # define PERMISSIONS_EXTENSION          ".permission"
 # define PERMISSIONS_PATTERN            "[A-Z]*" PERMISSIONS_EXTENSION
 
-/* Applications  from: *.desktop */
+/* Applications from: *.desktop */
 # define APPLICATIONS_DIRECTORY         DATADIR "/applications"
 # define APPLICATIONS_EXTENSION         ".desktop"
 # define APPLICATIONS_PATTERN           "*" APPLICATIONS_EXTENSION
+
+/* Sailjail overrides from: *.desktop */
+# define SAILJAIL_APP_DIRECTORY         SYSCONFDIR "/sailjail/applications"
 
 /* Settings from: *.settings */
 # define SETTINGS_DIRECTORY             SHAREDSTATEDIR "/sailjail/settings"
@@ -129,13 +132,14 @@ char *strip(char *str);
  * PATH
  * ------------------------------------------------------------------------- */
 
-const gchar *path_basename            (const gchar *path);
-const gchar *path_extension           (const gchar *path);
-gchar       *path_dirname             (const gchar *path);
-gchar       *path_to_desktop_name     (const gchar *path);
-gchar       *path_from_desktop_name   (const gchar *stem);
-gchar       *path_to_permission_name  (const gchar *path);
-gchar       *path_from_permission_name(const gchar *stem);
+const gchar *path_basename             (const gchar *path);
+const gchar *path_extension            (const gchar *path);
+gchar       *path_dirname              (const gchar *path);
+gchar       *path_to_desktop_name      (const gchar *path);
+gchar       *path_from_desktop_name    (const gchar *stem);
+gchar       *alt_path_from_desktop_name(const gchar *stem);
+gchar       *path_to_permission_name   (const gchar *path);
+gchar       *path_from_permission_name (const gchar *stem);
 
 /* ------------------------------------------------------------------------- *
  * GUTIL

--- a/daemon/util.h
+++ b/daemon/util.h
@@ -162,7 +162,7 @@ bool change_string_steal(gchar **pstr, gchar *val);
 
 bool         keyfile_save         (GKeyFile *file, const gchar *path);
 bool         keyfile_load         (GKeyFile *file, const gchar *path);
-void         keyfile_merge        (GKeyFile *file, const gchar *path);
+bool         keyfile_merge        (GKeyFile *file, const gchar *path);
 bool         keyfile_get_boolean  (GKeyFile *file, const gchar *sec, const gchar *key, bool def);
 gint         keyfile_get_integer  (GKeyFile *file, const gchar *sec, const gchar *key, gint def);
 gchar       *keyfile_get_string   (GKeyFile *file, const gchar *sec, const gchar *key, const gchar *def);

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -100,6 +100,7 @@ install -d %{buildroot}%{_sysconfdir}/dbus-1/system.d
 install -m644 daemon/dbus/sailjaild.conf %{buildroot}%{_sysconfdir}/dbus-1/system.d/sailjaild.conf
 install -d %{buildroot}%{_sharedstatedir}/sailjail/settings
 install -d %{buildroot}%{_sysconfdir}/sailjail/config
+install -d %{buildroot}%{_sysconfdir}/sailjail/applications
 
 %check
 make HAVE_FIREJAIL=%{jailfish} -C unit test
@@ -131,4 +132,6 @@ make HAVE_FIREJAIL=%{jailfish} -C unit test
 %config %{_sysconfdir}/dbus-1/system.d/sailjaild.conf
 %attr(0755,root,root) %dir %ghost %{_sharedstatedir}/sailjail
 %attr(0750,root,root) %dir %ghost %{_sharedstatedir}/sailjail/settings
+%dir %{_sysconfdir}/sailjail
 %dir %{_sysconfdir}/sailjail/config
+%dir %{_sysconfdir}/sailjail/applications


### PR DESCRIPTION
Add monitoring and scanning of /etc/sailjail/applications. Files in both
locations are combined.

Alternative location at /etc/sailjail/applications overrides keys
defined in /usr/share/applications if both have defined the same key.