### PR TITLE
Automatically grant allowlisted apps

### DIFF
--- a/daemon/.depend
+++ b/daemon/.depend
@@ -209,6 +209,7 @@ session.pic.o:\
 settings.o:\
 	settings.c\
 	appinfo.h\
+	config.h\
 	control.h\
 	logging.h\
 	settings.h\
@@ -218,6 +219,7 @@ settings.o:\
 settings.pic.o:\
 	settings.c\
 	appinfo.h\
+	config.h\
 	control.h\
 	logging.h\
 	settings.h\

--- a/daemon/settings.h
+++ b/daemon/settings.h
@@ -71,6 +71,14 @@ typedef enum
     // keep app_agreed_name[] in sync
 } app_agreed_t;
 
+typedef enum {
+    APP_GRANT_DEFAULT, // Take default
+    APP_GRANT_ALWAYS,  // Always allow all permissions
+    APP_GRANT_LAUNCH,  // Allow launching, user may control permissions
+    APP_GRANT_COUNT
+    // keep app_grant_name[] in sync
+} app_grant_t;
+
 /* ========================================================================= *
  * Prototypes
  * ========================================================================= */


### PR DESCRIPTION
Add autogrant property to appsettings. This returns app_grant_t value
that tells if and how application can be automatically granted launch or
permissions. This is controlled by allowlist section in configuration
which is static. APP_ALLOW_NEVER disables application launch even if
autogrant would normally allow it.
    
Autogrant has two modes: always allowing everything and allowing launch.
In the first mode, user or MDM can not disable any permissions. In the
second mode, it allows permissions by default but they can be denied.
    
Adjust setters to cope with autogrant values. Store old autogrant value
in settings file so that decoding can adjust allow and granted values to
changed autogrant configuration.
