### PR TITLE
Add minimal unit tests for sailjaild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,16 @@
 build
 unit/coverage/report
 unit/coverage/*.gcov
+*.o
+*.core
+/daemon/sailjaild
+/daemon/test/test_appinfo
+/daemon/test/test_permissions
+/daemon/test/test_settings
+/daemon/test/test_stringset
+/daemon/test/test_util
+/daemon/test/*.gc*
+/daemon/test/*.html
+/daemon/test/sailjail/permissions/
+/report/
+/coverage

--- a/daemon/Makefile
+++ b/daemon/Makefile
@@ -5,30 +5,10 @@
 VERSION   ?= $(shell awk '/^Version:/ {print $$2}' ../rpm/sailjail.spec)
 
 # ----------------------------------------------------------------------------
-# Installation directories
+# Installation directories and pkg-config
 # ----------------------------------------------------------------------------
 
-# Dummy default install dir - override from packaging scripts
-DESTDIR         ?= /tmp/sailjaild-test-install
-
-# Standard install directories
-_PREFIX         ?= /usr#                         # /usr
-_INCLUDEDIR     ?= $(_PREFIX)/include#           # /usr/include
-_EXEC_PREFIX    ?= $(_PREFIX)#                   # /usr
-_BINDIR         ?= $(_EXEC_PREFIX)/bin#          # /usr/bin
-_SBINDIR        ?= $(_EXEC_PREFIX)/sbin#         # /usr/sbin
-_LIBEXECDIR     ?= $(_EXEC_PREFIX)/libexec#      # /usr/libexec
-_LIBDIR         ?= $(_EXEC_PREFIX)/lib#          # /usr/lib
-_SYSCONFDIR     ?= /etc#                         # /etc
-_DATADIR        ?= $(_PREFIX)/share#             # /usr/share
-_MANDIR         ?= $(_DATADIR)/man#              # /usr/share/man
-_INFODIR        ?= $(_DATADIR)/info#             # /usr/share/info
-_DEFAULTDOCDIR  ?= $(_DATADIR)/doc#              # /usr/share/doc
-_LOCALSTATEDIR  ?= /var#                         # /var
-_SHAREDSTATEDIR ?= $(_LOCALSTATEDIR)/lib#        # /var/lib
-_UNITDIR        ?= /lib/systemd/system#
-_USERUNITDIR    ?= /lib/systemd/user#
-_TESTSDIR       ?= /opt/tests#                   # /opt/tests
+include Makefile.inc
 
 # ----------------------------------------------------------------------------
 # List of targets to build
@@ -45,7 +25,7 @@ TARGETS += ${TARGETS_BIN} ${TARGETS_PNG}
 # Top level targets
 # ----------------------------------------------------------------------------
 
-.PHONY: build install clean distclean mostlyclean
+.PHONY: build install clean distclean mostlyclean test-build test-install test-clean
 
 build:: $(TARGETS)
 
@@ -62,66 +42,14 @@ distclean:: clean
 mostlyclean::
 	$(RM) *.o *~ *.bak */*.o */*~ */*.bak
 
-# ----------------------------------------------------------------------------
-# Default flags
-# ----------------------------------------------------------------------------
+test-build::
+	$(MAKE) -C test build
 
-CPPFLAGS += -DVERSION='"${VERSION}"'
-CPPFLAGS += -DSYSCONFDIR='"${_SYSCONFDIR}"'
-CPPFLAGS += -DSHAREDSTATEDIR='"${_SHAREDSTATEDIR}"'
-CPPFLAGS += -DDATADIR='"${_DATADIR}"'
-CPPFLAGS += -DBINDIR='"${_BINDIR}"'
+test-install::
+	$(MAKE) -C test install
 
-CPPFLAGS += -D_GNU_SOURCE
-CPPFLAGS += -D_FILE_OFFSET_BITS=64
-
-COMMON   += -Wall
-COMMON   += -Os
-#COMMON   += -O0
-COMMON   += -g
-
-CFLAGS   += $(COMMON)
-CFLAGS   += -std=c99
-
-CXXFLAGS += $(COMMON)
-
-LDFLAGS  += -g
-
-LDLIBS   += -Wl,--as-needed
-
-# ----------------------------------------------------------------------------
-# Flags from pkg-config
-# ----------------------------------------------------------------------------
-
-PKG_NAMES += glib-2.0
-PKG_NAMES += gobject-2.0
-PKG_NAMES += gio-2.0
-PKG_NAMES += libsystemd
-
-HAVE_LIBDBUSACCESS := $(strip $(shell pkg-config --exists libdbusaccess && echo y))
-
-ifdef HAVE_LIBDBUSACCESS
-PKG_NAMES += libdbusaccess
-CPPFLAGS += -DHAVE_LIBDBUSACCESS
-endif
-
-maintenance  = normalize clean distclean mostlyclean
-intersection = $(strip $(foreach w,$1, $(filter $w,$2)))
-ifneq ($(call intersection,$(maintenance),$(MAKECMDGOALS)),)
-PKG_CONFIG   ?= true
-endif
-
-ifneq ($(strip $(PKG_NAMES)),)
-PKG_CONFIG   ?= pkg-config
-PKG_CFLAGS   := $(shell $(PKG_CONFIG) --cflags $(PKG_NAMES))
-PKG_LDLIBS   := $(shell $(PKG_CONFIG) --libs   $(PKG_NAMES))
-PKG_CPPFLAGS := $(filter -D%,$(PKG_CFLAGS)) $(filter -I%,$(PKG_CFLAGS))
-PKG_CFLAGS   := $(filter-out -I%, $(filter-out -D%, $(PKG_CFLAGS)))
-endif
-
-CPPFLAGS += $(PKG_CPPFLAGS)
-CFLAGS   += $(PKG_CFLAGS)
-LDLIBS   += $(PKG_LDLIBS)
+test-clean::
+	$(MAKE) -C test clean
 
 # ----------------------------------------------------------------------------
 # Implicit rules

--- a/daemon/Makefile.inc
+++ b/daemon/Makefile.inc
@@ -1,0 +1,87 @@
+# ----------------------------------------------------------- -*- mode: sh -*-
+# Installation directories
+# ----------------------------------------------------------------------------
+
+# Dummy default install dir - override from packaging scripts
+DESTDIR         ?= /tmp/sailjaild-test-install
+
+# Standard install directories
+_PREFIX         ?= /usr#                         # /usr
+_INCLUDEDIR     ?= $(_PREFIX)/include#           # /usr/include
+_EXEC_PREFIX    ?= $(_PREFIX)#                   # /usr
+_BINDIR         ?= $(_EXEC_PREFIX)/bin#          # /usr/bin
+_SBINDIR        ?= $(_EXEC_PREFIX)/sbin#         # /usr/sbin
+_LIBEXECDIR     ?= $(_EXEC_PREFIX)/libexec#      # /usr/libexec
+_LIBDIR         ?= $(_EXEC_PREFIX)/lib#          # /usr/lib
+_SYSCONFDIR     ?= /etc#                         # /etc
+_DATADIR        ?= $(_PREFIX)/share#             # /usr/share
+_MANDIR         ?= $(_DATADIR)/man#              # /usr/share/man
+_INFODIR        ?= $(_DATADIR)/info#             # /usr/share/info
+_DEFAULTDOCDIR  ?= $(_DATADIR)/doc#              # /usr/share/doc
+_LOCALSTATEDIR  ?= /var#                         # /var
+_SHAREDSTATEDIR ?= $(_LOCALSTATEDIR)/lib#        # /var/lib
+_UNITDIR        ?= /lib/systemd/system#
+_USERUNITDIR    ?= /lib/systemd/user#
+_TESTSDIR       ?= /opt/tests#                   # /opt/tests
+
+# ----------------------------------------------------------------------------
+# Default flags
+# ----------------------------------------------------------------------------
+
+CPPFLAGS += -DVERSION='"${VERSION}"'
+CPPFLAGS += -DSYSCONFDIR='"${_SYSCONFDIR}"'
+CPPFLAGS += -DSHAREDSTATEDIR='"${_SHAREDSTATEDIR}"'
+CPPFLAGS += -DDATADIR='"${_DATADIR}"'
+
+CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -D_FILE_OFFSET_BITS=64
+
+COMMON   += -Wall
+COMMON   += -Os
+#COMMON   += -O0
+COMMON   += -g
+
+CFLAGS   += $(COMMON)
+CFLAGS   += -std=c99
+
+CXXFLAGS += $(COMMON)
+
+LDFLAGS  += -g
+
+LDLIBS   += -Wl,--as-needed
+
+# ----------------------------------------------------------------------------
+# Flags from pkg-config
+# ----------------------------------------------------------------------------
+
+PKG_NAMES += glib-2.0
+PKG_NAMES += gobject-2.0
+PKG_NAMES += gio-2.0
+PKG_NAMES += libsystemd
+
+HAVE_LIBDBUSACCESS := $(strip $(shell pkg-config --exists libdbusaccess && echo y))
+
+ifdef HAVE_LIBDBUSACCESS
+PKG_NAMES += libdbusaccess
+CPPFLAGS += -DHAVE_LIBDBUSACCESS
+endif
+
+maintenance  = normalize clean distclean mostlyclean
+intersection = $(strip $(foreach w,$1, $(filter $w,$2)))
+ifneq ($(call intersection,$(maintenance),$(MAKECMDGOALS)),)
+PKG_CONFIG   ?= true
+endif
+
+ifneq ($(strip $(PKG_NAMES)),)
+PKG_CONFIG   ?= pkg-config
+PKG_CFLAGS   := $(shell $(PKG_CONFIG) --cflags $(PKG_NAMES))
+PKG_LDLIBS   := $(shell $(PKG_CONFIG) --libs   $(PKG_NAMES))
+PKG_CPPFLAGS := $(filter -D%,$(PKG_CFLAGS)) $(filter -I%,$(PKG_CFLAGS))
+PKG_CFLAGS   := $(filter-out -I%, $(filter-out -D%, $(PKG_CFLAGS)))
+endif
+
+CPPFLAGS += $(PKG_CPPFLAGS)
+CFLAGS   += $(PKG_CFLAGS)
+LDLIBS   += $(PKG_LDLIBS)
+
+# vim: set filetype=make:

--- a/daemon/test/Makefile
+++ b/daemon/test/Makefile
@@ -1,0 +1,184 @@
+# ----------------------------------------------------------- -*- mode: sh -*-
+#  Directory definitions and pkg-config
+# ----------------------------------------------------------------------------
+
+# Tests specific paths
+_TESTDATA       ?= /tmp/sailjail-daemon-tests
+_TESTSDIR       ?= /opt/tests
+_BINDIR         ?= $(_TESTSDIR)/sailjail-daemon/bin
+_TESTDATADIR    ?= $(_TESTSDIR)/sailjail-daemon/data
+_PREFIX         ?= $(_TESTSDIR)/sailjail-daemon/usr
+_SYSCONFDIR     ?= $(_TESTSDIR)/sailjail-daemon/etc
+_LOCALSTATEDIR  ?= $(_TESTDATA)/var
+
+include ../Makefile.inc
+
+CPPFLAGS += -DTESTDATADIR='"${_TESTDATADIR}"' -I..
+
+# ----------------------------------------------------------------------------
+#  Tests
+# ----------------------------------------------------------------------------
+
+TARGETS_BIN += test_appinfo
+TARGETS_BIN += test_permissions
+TARGETS_BIN += test_settings
+TARGETS_BIN += test_stringset
+TARGETS_BIN += test_util
+
+TARGETS += ${TARGETS_BIN}
+
+# ----------------------------------------------------------------------------
+#  Static test data
+# ----------------------------------------------------------------------------
+
+DATA_FILES += data/keyfile1.ini
+DATA_FILES += data/keyfile2.ini
+DATA_FILES += data/user-1000.settings
+
+APPLICATIONS_FILES += $(wildcard sailjail/applications/*.desktop)
+
+# ----------------------------------------------------------------------------
+# Top level targets
+# ----------------------------------------------------------------------------
+
+.PHONY: build install install-static clean mostlyclean
+
+build:: $(TARGETS)
+
+install:: build install-static install-tests
+	install -d ${DESTDIR}${_BINDIR}
+	install -m755 ${TARGETS_BIN} ${DESTDIR}${_BINDIR}
+
+install-static:: install-data install-applications
+
+clean:: mostlyclean
+	$(RM) $(TARGETS)
+
+mostlyclean::
+	$(RM) *.o *~ *.bak */*.o */*~ */*.bak *.gcda *.gcno
+	$(RM) -r $(PWD)/coverage $(PWD)/report/
+
+# ----------------------------------------------------------------------------
+# Testing targets
+# ----------------------------------------------------------------------------
+
+.PHONY: run coverage coverage-run coverage-build
+
+# Runs without coverage
+run:: _SYSCONFDIR := $(CURDIR)
+run:: _DATADIR := $(CURDIR)/sailjail
+run:: _TESTDATADIR := $(CURDIR)/data
+run:: build copy-test-data run-tests
+
+# Runs with coverage
+coverage-run:: _SYSCONFDIR := $(CURDIR)
+coverage-run:: _DATADIR := $(CURDIR)/sailjail
+coverage-run:: _TESTDATADIR := $(CURDIR)/data
+coverage-run:: coverage-build copy-test-data run-tests
+
+# Builds with coverage on
+coverage-build:: CFLAGS += --coverage
+coverage-build:: build
+
+# Generates report
+coverage:: coverage-run
+	lcov $(LCOVFLAGS) -c -d . -b $(CURDIR) -o $(PWD)/coverage
+	genhtml $(GENHTMLFLAGS) -o $(PWD)/report $(PWD)/coverage
+	@echo file://$(PWD)/report/index.html
+
+# Generates report with branch coverage
+branches:: LCOVFLAGS += --rc lcov_branch_coverage=1
+branches:: GENHTMLFLAGS += --branch-coverage
+branches:: coverage
+
+# Keep in sync with tests.xml preparations
+copy-test-data:: DESTDIR=
+copy-test-data:: data/user-1000.settings install-permissions
+	$(RM) -rf $(_TESTDATA)
+	install -d $(_SHAREDSTATEDIR)/sailjail/settings
+	install -m755 data/user-1000.settings $(_SHAREDSTATEDIR)/sailjail/settings/
+
+run-tests:: $(TARGETS_BIN)
+	$(foreach test,$(TARGETS_BIN),./$(test);)
+
+# ----------------------------------------------------------------------------
+# Static file targets
+# ----------------------------------------------------------------------------
+
+install-data:: $(DATA_FILES)
+	install -d ${DESTDIR}/${_TESTDATADIR}
+	install -m755 $^ ${DESTDIR}/${_TESTDATADIR}
+
+install-applications:: $(APPLICATIONS_FILES)
+	install -d ${DESTDIR}/${_DATADIR}/applications
+	install -m755 $^ ${DESTDIR}/${_DATADIR}/applications
+
+install-tests:: tests.xml.in
+	install -d ${DESTDIR}/${_TESTSDIR}
+	sed -e 's|@TESTDATA@|${_TESTDATA}|g' \
+		-e 's|@TESTSDIR@|${_TESTSDIR}|g' \
+		-e 's|@SHAREDSTATEDIR@|${_SHAREDSTATEDIR}|g' \
+		-e 's|@BINDIR@|${_BINDIR}|g' \
+		tests.xml.in > ${DESTDIR}/${_TESTSDIR}/sailjail-daemon/tests.xml
+
+install-permissions::
+	install -d ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions
+	touch ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions/Audio.permission
+	touch ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions/Base.permission
+	touch ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions/Camera.permission
+	touch ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions/Contacts.permission
+	touch ${DESTDIR}${_SYSCONFDIR}/sailjail/permissions/some-app.profile
+
+# ----------------------------------------------------------------------------
+# Mocking flags
+# ----------------------------------------------------------------------------
+
+test_appinfo: private CFLAGS += \
+	-Wl,--wrap=applications_control \
+	-Wl,--wrap=applications_config \
+	-Wl,--wrap=config_stringset \
+	-Wl,--wrap=config_boolean \
+	-Wl,--wrap=control_available_permissions
+
+test_permissions: private CFLAGS += \
+	-Wl,--wrap=control_on_permissions_change
+
+test_settings: private CFLAGS += \
+	-Wl,--wrap=control_min_user \
+	-Wl,--wrap=control_max_user \
+	-Wl,--wrap=control_user_is_guest\
+	-Wl,--wrap=control_valid_user \
+	-Wl,--wrap=control_valid_application \
+	-Wl,--wrap=control_available_permissions \
+	-Wl,--wrap=control_appinfo\
+	-Wl,--wrap=control_on_settings_change \
+	-Wl,--wrap=config_string \
+	-Wl,--wrap=config_stringset \
+	-Wl,--wrap=config_boolean \
+	-Wl,--wrap=applications_control \
+	-Wl,--wrap=applications_config \
+	-Wl,--wrap=migrator_create \
+	-Wl,--wrap=migrator_delete_at \
+	-Wl,--wrap=migrator_on_settings_saved
+
+# ----------------------------------------------------------------------------
+# Dependencies
+# ----------------------------------------------------------------------------
+
+test_appinfo: appinfo.o stringset.o util.o logging.o
+
+test_permissions: permissions.o stringset.o util.o logging.o
+
+test_settings: settings.o appinfo.o stringset.o util.o logging.o
+
+test_stringset: stringset.o
+
+test_util: util.o logging.o stringset.o
+
+# ----------------------------------------------------------------------------
+# Implicit rules
+# ----------------------------------------------------------------------------
+
+# Pick files from parent directory
+%.o: ../%.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) $^ -o $@ -c

--- a/daemon/test/data/keyfile1.ini
+++ b/daemon/test/data/keyfile1.ini
@@ -1,0 +1,7 @@
+[GroupA]
+KeyA1=ValueA1
+KeyA2=ValueA2
+
+[GroupB]
+KeyB1=ValueB1
+KeyB2=ValueB2

--- a/daemon/test/data/keyfile2.ini
+++ b/daemon/test/data/keyfile2.ini
@@ -1,0 +1,7 @@
+[GroupB]
+KeyB1=OverrideB1
+KeyB2=ValueB2
+
+[GroupC]
+KeyC1=ValueC1
+KeyC2=ValueC2

--- a/daemon/test/data/user-1000.settings
+++ b/daemon/test/data/user-1000.settings
@@ -1,0 +1,6 @@
+[test-app]
+Allowed=1
+Agreed=0
+Autogrant=0
+Granted=Internet
+Permissions=Internet

--- a/daemon/test/sailjail/applications/invalid-app.desktop
+++ b/daemon/test/sailjail/applications/invalid-app.desktop
@@ -1,0 +1,3 @@
+[Desktop Entry]
+Name=Invalid Application
+Exec=/foo/bar

--- a/daemon/test/sailjail/applications/test-app.desktop
+++ b/daemon/test/sailjail/applications/test-app.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Name=Test Application
+Type=Application
+Icon=test
+Exec=/usr/bin/true
+
+[X-Sailjail]
+OrganizationName=org.example
+ApplicationName=TestApplication
+Permissions=Internet;NonExistingPermission

--- a/daemon/test/test_appinfo.c
+++ b/daemon/test/test_appinfo.c
@@ -1,0 +1,179 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "appinfo.h"
+#include "stringset.h"
+
+#include <glib.h>
+#include <locale.h>
+
+/* ========================================================================= *
+ * MOCK DATA
+ * ========================================================================= */
+
+typedef struct {
+    stringset_t *mck_ctl_available_permissions;
+} appinfo_test_mock_t;
+
+void
+appinfo_test_mock_init(appinfo_test_mock_t *mock)
+{
+    mock->mck_ctl_available_permissions = stringset_create();
+    stringset_add_item(mock->mck_ctl_available_permissions, "Audio");
+    stringset_add_item(mock->mck_ctl_available_permissions, "Internet");
+    stringset_add_item(mock->mck_ctl_available_permissions, "Pictures");
+}
+
+/* ========================================================================= *
+ * MOCK CONTROL FUNCTIONS
+ * ========================================================================= */
+
+const stringset_t *
+__wrap_control_available_permissions(const control_t *self)
+{
+    const appinfo_test_mock_t *mock = (const appinfo_test_mock_t *)self;
+    return mock->mck_ctl_available_permissions;
+}
+
+/* ========================================================================= *
+ * MOCK APPLICATIONS FUNCTIONS
+ * ========================================================================= */
+
+control_t *
+__wrap_applications_control(const applications_t *self)
+{
+    const appinfo_test_mock_t *mock = (const appinfo_test_mock_t *)self;
+    return (control_t *)mock;
+}
+
+config_t *
+__wrap_applications_config(applications_t *self)
+{
+    const appinfo_test_mock_t *mock = (const appinfo_test_mock_t *)self;
+    return (config_t *)mock;
+}
+
+/* ========================================================================= *
+ * MOCK CONFIG_FUNCTIONS
+ * ========================================================================= */
+
+stringset_t *
+__wrap_config_stringset(config_t *self, const gchar *sec, const gchar *key)
+{
+    (void)self; // unused
+    (void)sec; // unused
+    (void)key; // unused
+    return stringset_create();
+}
+
+bool
+__wrap_config_boolean(config_t *self, const gchar *sec, const gchar *key, bool def)
+{
+    (void)self; // unused
+    (void)sec; // unused
+    (void)key; // unused
+    return def;
+}
+
+/* ========================================================================= *
+ * APPINFO TESTS
+ * ========================================================================= */
+
+void test_appinfo_create_missing(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "test-not-an-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_false(appinfo_valid(appinfo));
+    appinfo_delete(appinfo);
+}
+
+void test_appinfo_create_invalid(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "invalid-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_false(appinfo_valid(appinfo));
+    appinfo_delete(appinfo);
+}
+
+void test_appinfo_read_properties(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "test-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_true(appinfo_valid(appinfo));
+    g_assert_cmpstr(appinfo_get_name(appinfo), ==, "Test Application");
+    g_assert_cmpstr(appinfo_get_type(appinfo), ==, "Application");
+    g_assert_cmpstr(appinfo_get_icon(appinfo), ==, "test");
+    g_assert_cmpstr(appinfo_get_exec(appinfo), ==, "/usr/bin/true");
+    g_assert_cmpstr(appinfo_get_organization_name(appinfo), ==, "org.example");
+    g_assert_cmpstr(appinfo_get_application_name(appinfo), ==, "TestApplication");
+    appinfo_delete(appinfo);
+}
+
+void test_appinfo_permissions(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "test-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_true(appinfo_valid(appinfo));
+    g_assert_true(appinfo_has_permission(appinfo, "Internet"));
+    g_assert_false(appinfo_has_permission(appinfo, "Pictures"));
+    g_assert_false(appinfo_has_permission(appinfo, "NonExistingPermission"));
+    appinfo_delete(appinfo);
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int main(int argc, char **argv)
+{
+    appinfo_test_mock_t mock;
+    appinfo_test_mock_init(&mock);
+
+    setlocale(LC_ALL, "");
+
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_data_func("/sailjaild/appinfo/create_missing", &mock, test_appinfo_create_missing);
+    g_test_add_data_func("/sailjaild/appinfo/create_invalid", &mock, test_appinfo_create_invalid);
+    g_test_add_data_func("/sailjaild/appinfo/read_properties", &mock, test_appinfo_read_properties);
+    g_test_add_data_func("/sailjaild/appinfo/permissions", &mock, test_appinfo_permissions);
+
+    return g_test_run();
+}

--- a/daemon/test/test_permissions.c
+++ b/daemon/test/test_permissions.c
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "permissions.h"
+#include "stringset.h"
+#include "util.h"
+
+#include <glib.h>
+#include <locale.h>
+#include <stdio.h>
+#include <unistd.h>
+
+/* ========================================================================= *
+ * MOCK DATA
+ * ========================================================================= */
+
+typedef struct {
+    bool mck_change_signaled;
+    GMainLoop *main_loop;
+} permissions_test_mock_t;
+
+void
+permissions_test_mock_init(permissions_test_mock_t *mock)
+{
+    mock->mck_change_signaled = false;
+    mock->main_loop = g_main_loop_new(NULL, TRUE);
+}
+
+/* ========================================================================= *
+ * MOCK CONTROL FUNCTIONS
+ * ========================================================================= */
+
+void
+__wrap_control_on_permissions_change(control_t *self)
+{
+    permissions_test_mock_t *mock = (permissions_test_mock_t *)self;
+    mock->mck_change_signaled = true;
+    g_main_loop_quit(mock->main_loop);
+}
+
+/* ========================================================================= *
+ * Utility
+ * ========================================================================= */
+
+gboolean
+permissions_test_timeout(gpointer user_data)
+{
+    permissions_test_mock_t *mock = (permissions_test_mock_t *)user_data;
+    g_main_loop_quit(mock->main_loop);
+    return G_SOURCE_REMOVE;
+}
+
+void
+permissions_test_add_timeout(permissions_test_mock_t *mock)
+{
+    /* Timeout the test after ten seconds and quit main loop
+     * if the expected signal doesn't fire
+     */
+    static guint timeout = 0;
+    if( timeout )
+        g_source_remove(timeout);
+    timeout = g_timeout_add_seconds_full(G_PRIORITY_LOW, 10,
+                                         permissions_test_timeout, mock, NULL);
+}
+
+/* ========================================================================= *
+ * PERMISSIONS TESTS
+ * ========================================================================= */
+
+void test_permissions_create_delete()
+{
+    permissions_t *permissions = permissions_create(NULL);
+    g_assert_nonnull(permissions);
+    permissions_delete_at(&permissions);
+    g_assert_null(permissions);
+    permissions_delete_at(&permissions);
+    g_assert_null(permissions);
+}
+
+void test_permissions_available()
+{
+    permissions_t *permissions = permissions_create(NULL);
+    const stringset_t *available = permissions_available(permissions);
+    g_assert_cmpint(stringset_size(available), ==, 4);
+    g_assert_true(stringset_has_item(available, "Audio"));
+    g_assert_false(stringset_has_item(available, "Base"));
+    g_assert_true(stringset_has_item(available, "Camera"));
+    g_assert_true(stringset_has_item(available, "Contacts"));
+    g_assert_true(stringset_has_item(available, "Privileged"));
+    g_assert_false(stringset_has_item(available, "some-app"));
+    g_assert_false(stringset_has_item(available, "some-app.profile"));
+    permissions_delete(permissions);
+}
+
+void test_permissions_changed(gconstpointer user_data)
+{
+    permissions_test_mock_t *mock = (permissions_test_mock_t *)user_data;
+    permissions_t *permissions = permissions_create((control_t *)mock);
+    const stringset_t *available = permissions_available(permissions);
+    g_assert_false(stringset_has_item(available, "Test"));
+    /* First test adding a permission */
+    permissions_test_add_timeout(mock);
+    FILE *file = fopen(PERMISSIONS_DIRECTORY "/Test.permission", "a");
+    g_assert_nonnull(file);
+    g_assert_cmpint(fclose(file), ==, 0);
+    g_main_loop_run(mock->main_loop);
+    g_assert_true(mock->mck_change_signaled);
+    available = permissions_available(permissions);
+    g_assert_true(stringset_has_item(available, "Test"));
+    /* Second test removing a permission */
+    permissions_test_add_timeout(mock);
+    mock->mck_change_signaled = false;
+    g_assert_cmpint(unlink(PERMISSIONS_DIRECTORY "/Test.permission"), ==, 0);
+    g_main_loop_run(mock->main_loop);
+    g_assert_true(mock->mck_change_signaled);
+    available = permissions_available(permissions);
+    g_assert_false(stringset_has_item(available, "Test"));
+    permissions_delete(permissions);
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int main(int argc, char **argv)
+{
+    permissions_test_mock_t mock;
+    permissions_test_mock_init(&mock);
+
+    setlocale(LC_ALL, "");
+
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/sailjaild/permissions/create_and_delete", test_permissions_create_delete);
+    g_test_add_func("/sailjaild/permissions/available", test_permissions_available);
+    g_test_add_data_func("/sailjaild/permissions/changed", &mock, test_permissions_changed);
+
+    return g_test_run();
+}

--- a/daemon/test/test_settings.c
+++ b/daemon/test/test_settings.c
@@ -1,0 +1,252 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "settings.h"
+#include "appinfo.h"
+#include "stringset.h"
+
+#include <glib.h>
+#include <locale.h>
+
+/* ========================================================================= *
+ * MOCK DATA
+ * ========================================================================= */
+
+#define MIN_USER 1000
+#define MAX_USER 1000
+#define GUEST_USER 1050
+
+typedef struct {
+    bool mck_guest_valid;
+    stringset_t *mck_ctl_available_permissions;
+    stringset_t *mck_ctl_valid_applications;
+} settings_test_mock_t;
+
+void
+settings_test_mock_init(settings_test_mock_t *mock)
+{
+    mock->mck_guest_valid = true;
+    mock->mck_ctl_available_permissions = stringset_create();
+    stringset_add_item(mock->mck_ctl_available_permissions, "Audio");
+    stringset_add_item(mock->mck_ctl_available_permissions, "Internet");
+    stringset_add_item(mock->mck_ctl_available_permissions, "Pictures");
+    mock->mck_ctl_valid_applications = stringset_create();
+    stringset_add_item(mock->mck_ctl_valid_applications, "test-app");
+}
+
+/* ========================================================================= *
+ * MOCK CONTROL FUNCTIONS
+ * ========================================================================= */
+
+uid_t
+__wrap_control_min_user(const control_t *self)
+{
+    (void)self; // unused
+    return MIN_USER;
+}
+
+uid_t
+__wrap_control_max_user(const control_t *self)
+{
+    (void)self; // unused
+    return MAX_USER;
+}
+
+bool
+__wrap_control_user_is_guest(const control_t *self, uid_t uid)
+{
+    (void)self; // unused
+    return uid == GUEST_USER;
+}
+
+bool
+__wrap_control_valid_user(const control_t *self, uid_t uid)
+{
+    const settings_test_mock_t *mock = (const settings_test_mock_t *)self;
+    if( uid == GUEST_USER )
+        return mock->mck_guest_valid;
+    return uid >= MIN_USER && uid <= MAX_USER;
+}
+
+bool
+__wrap_control_valid_application(const control_t *self, const char *appname)
+{
+    const settings_test_mock_t *mock = (const settings_test_mock_t *)self;
+    return stringset_has_item(mock->mck_ctl_valid_applications, appname);
+}
+
+const stringset_t *
+__wrap_control_available_permissions(const control_t *self)
+{
+    const settings_test_mock_t *mock = (const settings_test_mock_t *)self;
+    return mock->mck_ctl_available_permissions;
+}
+
+appinfo_t *
+__wrap_control_appinfo(control_t *self, const gchar *appname)
+{
+    settings_test_mock_t *mock = (settings_test_mock_t *)self;
+    appinfo_t *appinfo = appinfo_create((applications_t *)mock, appname);
+    appinfo_parse_desktop(appinfo);
+    return appinfo;
+}
+
+void
+__wrap_control_on_settings_change(control_t *self, const gchar *appname)
+{
+    (void)self; // unused
+    (void)appname; // unused
+}
+
+/* ========================================================================= *
+ * MOCK CONFIG FUNCTIONS
+ * ========================================================================= */
+
+gchar *
+__wrap_config_string(const config_t *self, const gchar *sec, const gchar *key, const gchar *def)
+{
+    (void)self; // unused
+    (void)sec; // unused
+    (void)key; // unused
+    return g_strdup(def);
+}
+
+stringset_t *
+__wrap_config_stringset(config_t *self, const gchar *sec, const gchar *key)
+{
+    (void)self; // unused
+    (void)sec; // unused
+    (void)key; // unused
+    return stringset_create();
+}
+
+bool
+__wrap_config_boolean(config_t *self, const gchar *sec, const gchar *key, bool def)
+{
+    (void)self; // unused
+    (void)sec; // unused
+    (void)key; // unused
+    return def;
+}
+
+/* ========================================================================= *
+ * MOCK APPLICATIONS FUNCTIONS
+ * ========================================================================= */
+
+control_t *
+__wrap_applications_control(const applications_t *self)
+{
+    settings_test_mock_t *mock = (settings_test_mock_t *)self;
+    return (control_t *)mock;
+}
+
+config_t *
+__wrap_applications_config(applications_t *self)
+{
+    settings_test_mock_t *mock = (settings_test_mock_t *)self;
+    return (config_t *)mock;
+}
+
+/* ========================================================================= *
+ * MOCK MIGRATOR FUNCTIONS
+ * ========================================================================= */
+
+migrator_t *
+__wrap_migrator_create(control_t *control)
+{
+    return NULL;
+}
+
+void
+__wrap_migrator_delete_at(migrator_t **pself)
+{
+    (void)pself; // unused
+}
+
+void
+__wrap_migrator_on_settings_saved(migrator_t *self)
+{
+    (void)self; // unused
+}
+
+/* ========================================================================= *
+ * SETTINGS TESTS
+ * ========================================================================= */
+
+void test_settings_create_delete(gconstpointer user_data)
+{
+    settings_t *settings = settings_create((config_t *)user_data, (control_t *)user_data);
+    g_assert_nonnull(settings);
+    settings_delete_at(&settings);
+    g_assert_null(settings);
+    settings_delete_at(&settings);
+    g_assert_null(settings);
+}
+
+void test_settings_load(gconstpointer user_data)
+{
+    settings_t *settings = settings_create((config_t *)user_data, (control_t *)user_data);
+    settings_load_user(settings, 1000);
+    usersettings_t *usersettings = settings_get_usersettings(settings, 1000);
+    g_assert_nonnull(usersettings);
+    appsettings_t *appsettings = settings_get_appsettings(settings, 1000, "test-app");
+    g_assert_nonnull(appsettings);
+    g_assert_cmpint(appsettings_get_allowed(appsettings), ==, APP_ALLOWED_ALWAYS);
+    g_assert_cmpint(appsettings_get_agreed(appsettings), ==, APP_ALLOWED_UNSET);
+    const stringset_t *granted = appsettings_get_granted(appsettings);
+    g_assert_cmpint(stringset_size(granted), ==, 1);
+    g_assert_true(stringset_has_item(granted, "Internet"));
+    settings_delete(settings);
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int main(int argc, char **argv)
+{
+    settings_test_mock_t mock;
+    settings_test_mock_init(&mock);
+
+    setlocale(LC_ALL, "");
+
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_data_func("/sailjaild/settings/settings/create_and_delete", &mock, test_settings_create_delete);
+    g_test_add_data_func("/sailjaild/settings/settings/load", &mock, test_settings_load);
+
+    return g_test_run();
+}

--- a/daemon/test/test_stringset.c
+++ b/daemon/test/test_stringset.c
@@ -1,0 +1,266 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "stringset.h"
+
+#include <glib.h>
+#include <locale.h>
+
+/* ========================================================================= *
+ * SET UP AND TEAR DOWN
+ * ========================================================================= */
+
+typedef struct {
+    stringset_t *empty;
+    stringset_t *set;
+    char **names;
+} stringset_test_data_t;
+
+static void
+stringset_test_set_up(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    data->empty = stringset_create();
+    data->set   = stringset_create();
+    stringset_add_item(data->set, "foo");
+    stringset_add_item(data->set, "bar");
+    stringset_add_item(data->set, "baz");
+    data->names = g_malloc0_n(4, sizeof(*data->names));
+    data->names[0] = "foo";
+    data->names[1] = "bar";
+    data->names[2] = "baz";
+}
+
+static void
+stringset_test_tear_down(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_delete_at(&data->empty);
+    stringset_delete_at(&data->set);
+}
+
+/* ========================================================================= *
+ * STRINGSET TESTS
+ * ========================================================================= */
+
+void test_stringset_create_delete()
+{
+    stringset_t *set = stringset_create();
+    g_assert_nonnull(set);
+    stringset_delete_at(&set);
+    g_assert_null(set);
+    stringset_delete_at(&set);
+    g_assert_null(set);
+}
+
+void test_stringset_add_item()
+{
+    stringset_t *set = stringset_create();
+    g_assert_true(stringset_add_item(set, "foo"));
+    g_assert_true(stringset_add_item(set, "bar"));
+    g_assert_false(stringset_add_item(set, "foo"));
+    stringset_delete(set);
+}
+
+void test_stringset_remove_item(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    g_assert_true(stringset_remove_item(data->set, "foo"));
+    g_assert_true(stringset_remove_item(data->set, "bar"));
+    g_assert_false(stringset_remove_item(data->set, "foo"));
+    g_assert_cmpint(stringset_size(data->set), ==, 1);
+}
+
+void test_stringset_size(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    g_assert_cmpint(stringset_size(data->empty), ==, 0);
+    g_assert_cmpint(stringset_size(data->set), ==, 3);
+}
+
+void test_stringset_empty(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    g_assert_true(stringset_empty(data->empty));
+    g_assert_false(stringset_empty(data->set));
+}
+
+void test_stringset_has_item(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    g_assert_true(stringset_has_item(data->set, "bar"));
+    g_assert_false(stringset_has_item(data->set, "foobar"));
+}
+
+void test_stringset_to_string(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    gchar *text = stringset_to_string(data->set);
+    g_assert_cmpstr(text, ==, "foo,bar,baz");
+    g_free(text);
+}
+
+void test_stringset_to_strv(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    gchar **names = stringset_to_strv(data->set);
+    g_assert_cmpuint(g_strv_length(names), ==, g_strv_length(data->names));
+    for( size_t i = 0; names[i] && data->names[i]; ++i )
+        g_assert_cmpstr(names[i], ==, data->names[i]);
+    g_strfreev(names);
+}
+
+void test_stringset_from_strv(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_t *nameset = stringset_from_strv(data->names);
+    g_assert_true(stringset_equal(nameset, data->set));
+    stringset_delete(nameset);
+}
+
+void test_stringset_from_null_strv()
+{
+    stringset_t *set = stringset_from_strv(NULL);
+    g_assert_nonnull(set);
+    g_assert_true(stringset_empty(set));
+}
+
+void test_stringset_extend(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_t *extended = stringset_create();
+    stringset_add_item(extended, "1");
+    stringset_add_item(extended, "2");
+    stringset_add_item(extended, "bar");
+    g_assert_false(stringset_has_item(extended, "foo"));
+    g_assert_true(stringset_has_item(extended, "bar"));
+    g_assert_false(stringset_has_item(extended, "baz"));
+    stringset_extend(extended, data->set);
+    g_assert_true(stringset_has_item(extended, "1"));
+    g_assert_true(stringset_has_item(extended, "2"));
+    g_assert_true(stringset_has_item(extended, "foo"));
+    g_assert_true(stringset_has_item(extended, "bar"));
+    g_assert_true(stringset_has_item(extended, "baz"));
+    stringset_delete(extended);
+}
+
+void test_stringset_copy(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_t *copy = stringset_copy(data->set);
+    g_assert_true(stringset_equal(data->set, copy));
+    g_assert_true(stringset_has_item(copy, "foo"));
+    g_assert_true(stringset_has_item(copy, "bar"));
+    g_assert_true(stringset_has_item(copy, "baz"));
+    stringset_add_item(copy, "1");
+    stringset_add_item(copy, "2");
+    g_assert_false(stringset_equal(data->set, copy));
+    g_assert_false(stringset_has_item(data->set, "1"));
+    g_assert_false(stringset_has_item(data->set, "2"));
+    g_assert_true(stringset_has_item(copy, "1"));
+    g_assert_true(stringset_has_item(copy, "2"));
+    stringset_delete(copy);
+}
+
+void test_stringset_swap(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_swap(data->empty, data->set);
+    g_assert_true(stringset_has_item(data->empty, "foo"));
+    g_assert_true(stringset_has_item(data->empty, "bar"));
+    g_assert_true(stringset_has_item(data->empty, "baz"));
+    g_assert_false(stringset_has_item(data->set, "foo"));
+    g_assert_false(stringset_has_item(data->set, "bar"));
+    g_assert_false(stringset_has_item(data->set, "baz"));
+}
+
+void test_stringset_assign(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    g_assert_true(stringset_assign(data->empty, data->set));
+    g_assert_true(stringset_equal(data->empty, data->set));
+}
+
+void test_stringset_nonequal(stringset_test_data_t *data, gconstpointer user_data)
+{
+    (void)user_data; // unused
+    stringset_t *another = stringset_copy(data->set);
+    g_assert_true(stringset_remove_item(another, "baz"));
+    g_assert_true(stringset_add_item(another, "xxx"));
+    g_assert_false(stringset_equal(data->set, another));
+    stringset_delete(another);
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int main(int argc, char **argv)
+{
+    setlocale(LC_ALL, "");
+
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/sailjaild/stringset/create_and_delete", test_stringset_create_delete);
+    g_test_add_func("/sailjaild/stringset/add_item", test_stringset_add_item);
+    g_test_add("/sailjaild/stringset/remove_item", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_remove_item, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/size", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_size, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/empty", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_empty, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/has_item", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_has_item, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/to_string", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_to_string, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/to_strv", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_to_strv, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/from_strv", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_from_strv, stringset_test_tear_down);
+    g_test_add_func("/sailjaild/stringset/from_null_strv", test_stringset_from_null_strv);
+    g_test_add("/sailjaild/stringset/extend", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_extend, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/copy", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_copy, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/swap", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_swap, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/assign", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_assign, stringset_test_tear_down);
+    g_test_add("/sailjaild/stringset/nonequal", stringset_test_data_t, NULL,
+               stringset_test_set_up, test_stringset_nonequal, stringset_test_tear_down);
+
+    return g_test_run();
+}

--- a/daemon/test/test_util.c
+++ b/daemon/test/test_util.c
@@ -1,0 +1,394 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+#include "util.h"
+#include "stringset.h"
+
+#include <glib.h>
+#include <locale.h>
+
+/* ========================================================================= *
+ * STRIP TESTS
+ * ========================================================================= */
+
+void test_strip_basic()
+{
+    gchar *subject = g_strdup("  foo    bar  ");
+    gchar *result = strip(subject);
+    g_assert_true(result == subject);
+    g_assert_cmpstr(result, ==, "foo bar");
+    g_free(subject);
+}
+
+void test_strip_none()
+{
+    gchar *subject = g_strdup("foobar");
+    gchar *result = strip(subject);
+    g_assert_true(result == subject);
+    g_assert_cmpstr(result, ==, "foobar");
+    g_free(subject);
+}
+
+void test_strip_null()
+{
+    gchar *subject = g_strdup("");
+    gchar *result = strip(subject);
+    g_assert_true(result == subject);
+    g_assert_cmpstr(result, ==, "");
+    g_free(subject);
+    g_assert_null(strip(NULL));
+}
+
+/* ========================================================================= *
+ * PATH TESTS
+ * ========================================================================= */
+
+void test_path_basename()
+{
+    const gchar *result;
+    result = path_basename("/usr/share/applications/foo.desktop");
+    g_assert_cmpstr(result, ==, "foo.desktop");
+    result = path_basename("/tmp/foo");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_basename("/foo");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_basename("foo");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_basename(".foo");
+    g_assert_cmpstr(result, ==, ".foo");
+    result = path_basename("");
+    g_assert_cmpstr(result, ==, "");
+    result = path_basename(NULL);
+    g_assert_null(result);
+}
+
+void test_path_extension()
+{
+    const gchar *result;
+    result = path_extension("/usr/share/applications/foo.desktop");
+    g_assert_cmpstr(result, ==, ".desktop");
+    result = path_extension("foo.test");
+    g_assert_cmpstr(result, ==, ".test");
+    result = path_extension("foo.test.desktop");
+    g_assert_cmpstr(result, ==, ".desktop");
+    result = path_extension("/tmp/foo");
+    g_assert_null(result);
+    result = path_extension("/foo");
+    g_assert_null(result);
+    result = path_extension("foo");
+    g_assert_null(result);
+    /* Hidden files do not work as expected at the moment
+     * but this is sufficient for us, for now anyway!
+     */
+//    result = path_extension(".foo");
+//    g_assert_cmpstr(result, ==, "");
+    result = path_extension(NULL);
+    g_assert_null(result);
+}
+
+void test_path_dirname()
+{
+    {
+        gchar *result = path_dirname("/usr/share/applications/foo.desktop");
+        g_assert_cmpstr(result, ==, "/usr/share/applications");
+        g_free(result);
+    }
+    {
+        gchar *result = path_dirname("/tmp/foo.desktop");
+        g_assert_cmpstr(result, ==, "/tmp");
+        g_free(result);
+    }
+    {
+        gchar *result = path_dirname("/usr/share/applications/org.example.FooBar.desktop");
+        g_assert_cmpstr(result, ==, "/usr/share/applications");
+        g_free(result);
+    }
+    {
+        gchar *result = path_dirname("/foo.test");
+        g_assert_cmpstr(result, ==, "/");
+        g_free(result);
+    }
+    {
+        gchar *result = path_dirname("foo.test");
+        g_assert_cmpstr(result, ==, ".");
+        g_free(result);
+    }
+    {
+        gchar *result = path_dirname(NULL);
+        g_assert_null(result);
+    }
+}
+
+void test_path_to_desktop_name()
+{
+    const gchar *result;
+    result = path_to_desktop_name("/usr/share/applications/foo.desktop");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_to_desktop_name("/tmp/foo.desktop");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_to_desktop_name("/usr/share/applications/org.example.FooBar.desktop");
+    g_assert_cmpstr(result, ==, "org.example.FooBar");
+    result = path_to_desktop_name("/foo.test");
+    g_assert_cmpstr(result, ==, "foo.test");
+    result = path_to_desktop_name("foo.test");
+    g_assert_cmpstr(result, ==, "foo.test");
+    result = path_to_desktop_name("foo");
+    g_assert_cmpstr(result, ==, "foo");
+    result = path_to_desktop_name(NULL);
+    g_assert_null(result);
+}
+
+void test_path_from_permission_name()
+{
+    gchar *result = path_from_permission_name("Test");
+    g_assert_cmpstr(result, ==, PERMISSIONS_DIRECTORY "/Test.permission");
+    g_free(result);
+    result = path_to_permission_name(NULL);
+    g_assert_null(result);
+}
+
+/* ========================================================================= *
+ * CHANGE TESTS
+ * ========================================================================= */
+
+void test_change_uid()
+{
+    uid_t uid = 0;
+    g_assert_false(change_uid(&uid, 0));
+    g_assert_cmpint(uid, ==, 0);
+    g_assert_true(change_uid(&uid, 1));
+    g_assert_cmpint(uid, ==, 1);
+}
+
+void test_change_boolean()
+{
+    bool boolean = false;
+    g_assert_false(change_boolean(&boolean, false));
+    g_assert_false(boolean);
+    g_assert_true(change_boolean(&boolean, true));
+    g_assert_true(boolean);
+}
+
+void test_change_string()
+{
+    gchar *string = g_strdup("foo"); // consumed
+    g_assert_false(change_string(&string, "foo"));
+    g_assert_cmpstr(string, ==, "foo");
+    g_assert_true(change_string(&string, "bar"));
+    g_assert_cmpstr(string, ==, "bar");
+    g_assert_true(change_string(&string, NULL));
+    g_assert_null(string);
+    g_assert_false(change_string(&string, NULL));
+    g_assert_null(string);
+}
+
+void test_change_string_steal()
+{
+    gchar *string = g_strdup("foo"); // consumed
+    {
+        gchar *tmp = string;
+        gchar *another = g_strdup("foo"); // consumed
+        g_assert_false(change_string_steal(&string, another));
+        g_assert_cmpstr(string, ==, "foo");
+        g_assert_true(string == tmp);
+    }
+    {
+        gchar *another = g_strdup("bar"); // consumed
+        g_assert_true(change_string_steal(&string, another));
+        g_assert_cmpstr(string, ==, "bar");
+        g_assert_true(string == another);
+    }
+    g_assert_true(change_string_steal(&string, NULL));
+    g_assert_null(string);
+    g_assert_false(change_string_steal(&string, NULL));
+    g_assert_null(string);
+}
+
+/* ========================================================================= *
+ * KEYFILE TESTS
+ * ========================================================================= */
+
+void test_keyfile_merge()
+{
+    GKeyFile *keyfile = g_key_file_new();
+
+    {
+        g_assert_true(keyfile_merge(keyfile, TESTDATADIR "/keyfile1.ini"));
+        gchar *value = keyfile_get_string(keyfile, "GroupB", "KeyB1", "default");
+        g_assert_cmpstr(value, ==, "ValueB1");
+        g_free(value);
+    }
+    {
+        g_assert_true(keyfile_merge(keyfile, TESTDATADIR "/keyfile2.ini"));
+        gchar *value = keyfile_get_string(keyfile, "GroupB", "KeyB1", "default");
+        g_assert_cmpstr(value, ==, "OverrideB1");
+        g_free(value);
+    }
+
+    g_key_file_free(keyfile);
+}
+
+void test_keyfile_save()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    keyfile_set_boolean(keyfile, "Foo", "boolean", true);
+    keyfile_set_integer(keyfile, "Foo", "number", 100);
+    g_assert_true(keyfile_save(keyfile, SHAREDSTATEDIR "/test.ini"));
+    g_assert_true(g_file_test(SHAREDSTATEDIR "/test.ini", G_FILE_TEST_EXISTS));
+    g_key_file_unref(keyfile);
+    keyfile = g_key_file_new();
+    g_key_file_load_from_file(keyfile, SHAREDSTATEDIR "/test.ini", G_KEY_FILE_NONE, NULL);
+    g_assert_true(g_key_file_get_boolean(keyfile, "Foo", "boolean", NULL));
+    g_assert_cmpint(g_key_file_get_integer(keyfile, "Foo", "number", NULL), ==, 100);
+}
+
+void test_keyfile_non_existent()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    g_assert_false(keyfile_merge(keyfile, TESTDATADIR "/does_not_exist.ini"));
+}
+
+void test_keyfile_missing_values()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    g_assert_true(keyfile_load(keyfile, TESTDATADIR "/keyfile1.ini"));
+
+    bool boolvalue = keyfile_get_boolean(keyfile, "GroupA", "some_bool", false);
+    g_assert_false(boolvalue);
+    boolvalue = keyfile_get_boolean(keyfile, "GroupA", "some_bool", true);
+    g_assert_true(boolvalue);
+
+    int intvalue = keyfile_get_integer(keyfile, "GroupA", "some_int", -1);
+    g_assert_cmpint(intvalue, ==, -1);
+
+    gchar *strvalue = keyfile_get_string(keyfile, "GroupA", "some_string", "mydefault");
+    g_assert_cmpstr(strvalue, ==, "mydefault");
+    g_free(strvalue);
+
+    stringset_t *setvalue = keyfile_get_stringset(keyfile, "GroupA", "some_set");
+    g_assert_true(stringset_empty(setvalue));
+    stringset_delete(setvalue);
+
+    g_key_file_free(keyfile);
+}
+
+void test_keyfile_set_boolean()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    keyfile_set_boolean(keyfile, "Foo", "bar", true);
+    g_assert_true(g_key_file_get_boolean(keyfile, "Foo", "bar", NULL));
+}
+
+void test_keyfile_set_integer()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    keyfile_set_integer(keyfile, "Foo", "bar", 100);
+    g_assert_cmpint(g_key_file_get_integer(keyfile, "Foo", "bar", NULL), ==, 100);
+}
+
+void test_keyfile_set_string()
+{
+    GKeyFile *keyfile = g_key_file_new();
+    {
+        keyfile_set_string(keyfile, "Foo", "foo", "foobar");
+        gchar *result = g_key_file_get_string(keyfile, "Foo", "foo", NULL);
+        g_assert_cmpstr(result, ==, "foobar");
+        g_free(result);
+    }
+    {
+        keyfile_set_string(keyfile, "Foo", "bar", "");
+        gchar *result = g_key_file_get_string(keyfile, "Foo", "bar", NULL);
+        g_assert_cmpstr(result, ==, "");
+        g_free(result);
+    }
+    {
+        // keyfile_set_string sets an empty string instead of skipping
+        keyfile_set_string(keyfile, "Foo", "baz", NULL);
+        gchar *result = g_key_file_get_string(keyfile, "Foo", "baz", NULL);
+        g_assert_cmpstr(result, ==, "");
+        g_free(result);
+    }
+}
+
+void test_keyfile_set_stringset()
+{
+    gchar *result;
+    GKeyFile *keyfile = g_key_file_new();
+    stringset_t *set = stringset_create();
+    stringset_add_item(set, "foo");
+    stringset_add_item(set, "bar");
+    keyfile_set_stringset(keyfile, "Foo", "bar", set);
+    result = g_key_file_get_string(keyfile, "Foo", "bar", NULL);
+    g_assert_cmpstr(result, ==, "foo;bar;");
+    g_free(result);
+}
+
+/* ========================================================================= *
+ * MAIN
+ * ========================================================================= */
+
+int main(int argc, char **argv)
+{
+    setlocale(LC_ALL, "");
+
+    g_test_init(&argc, &argv, NULL);
+
+    g_test_add_func("/sailjaild/util/strip/basic", test_strip_basic);
+    g_test_add_func("/sailjaild/util/strip/none", test_strip_none);
+    g_test_add_func("/sailjaild/util/strip/null", test_strip_null);
+
+    g_test_add_func("/sailjaild/util/path/basename", test_path_basename);
+    g_test_add_func("/sailjaild/util/path/extension", test_path_extension);
+    g_test_add_func("/sailjaild/util/path/dirname", test_path_dirname);
+    g_test_add_func("/sailjaild/util/path/to_desktop_name", test_path_to_desktop_name);
+    g_test_add_func("/sailjaild/util/path/from_permission_name", test_path_from_permission_name);
+
+    g_test_add_func("/sailjaild/util/change/uid", test_change_uid);
+    g_test_add_func("/sailjaild/util/change/boolean", test_change_boolean);
+    g_test_add_func("/sailjaild/util/change/string", test_change_string);
+    g_test_add_func("/sailjaild/util/change/string_steal", test_change_string_steal);
+
+    g_test_add_func("/sailjaild/util/keyfile/merge", test_keyfile_merge);
+    g_test_add_func("/sailjaild/util/keyfile/non_existent", test_keyfile_non_existent);
+    g_test_add_func("/sailjaild/util/keyfile/missing_values", test_keyfile_missing_values);
+    g_test_add_func("/sailjaild/util/keyfile/save", test_keyfile_save);
+    g_test_add_func("/sailjaild/util/keyfile/set_boolean", test_keyfile_set_boolean);
+    g_test_add_func("/sailjaild/util/keyfile/set_integer", test_keyfile_set_integer);
+    g_test_add_func("/sailjaild/util/keyfile/set_string", test_keyfile_set_string);
+    g_test_add_func("/sailjaild/util/keyfile/set_stringset", test_keyfile_set_stringset);
+
+    return g_test_run();
+}

--- a/daemon/test/tests.xml.in
+++ b/daemon/test/tests.xml.in
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<testdefinition version="0.1">
+   <suite name="sailjail-daemon-tests" domain="mw">
+       <description>sailjail daemon tests</description>
+
+       <set name="sailjail-daemon" feature="sandboxing">
+           <description>sailjail daemon tests</description>
+           <pre_steps>
+               <step>rm -rf @TESTDATA@</step>
+               <step>mkdir -p @SHAREDSTATEDIR@/sailjail/settings</step>
+               <step>cp @TESTSDIR@/sailjail-daemon/data/user-1000.settings @SHAREDSTATEDIR@/sailjail/settings/</step>
+           </pre_steps>
+           <case name="util strip" level="Component" type="Functional">
+               <step>@BINDIR@/test_util -p "/sailjaild/util/strip"</step>
+           </case>
+           <case name="util path" level="Component" type="Functional">
+               <step>@BINDIR@/test_util -p "/sailjaild/util/path"</step>
+           </case>
+           <case name="util change" level="Component" type="Functional">
+               <step>@BINDIR@/test_util -p "/sailjaild/util/change"</step>
+           </case>
+           <case name="util keyfile" level="Component" type="Functional">
+               <step>@BINDIR@/test_util -p "/sailjaild/util/keyfile"</step>
+           </case>
+           <case name="stringset" level="Component" type="Functional">
+               <step>@BINDIR@/test_stringset</step>
+           </case>
+           <case name="appinfo" level="Component" type="Functional">
+               <step>@BINDIR@/test_appinfo</step>
+           </case>
+           <case name="settings" level="Component" type="Functional">
+               <step>@BINDIR@/test_settings -p /sailjaild/settings/settings</step>
+           </case>
+           <post_steps>
+               <step>rm -rf @TESTDATA@</step>
+           </post_steps>
+       </set>
+   </suite>
+</testdefinition>

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -30,9 +30,12 @@ BuildRequires: pkgconfig(gobject-2.0)
 BuildRequires: pkgconfig(gio-2.0)
 BuildRequires: pkgconfig(libsystemd)
 BuildRequires: pkgconfig(libdbusaccess)
+BuildRequires: sed
 
 # Keep settings in encrypted home partition
 %define _sharedstatedir /home/.system/var/lib
+# Tests directory
+%define _testsdir /opt/tests
 
 %description
 Firejail-based sanboxing for Sailfish OS.
@@ -62,6 +65,12 @@ This package contains daemon that keeps track of:
 - permissions required by applications (under /usr/share/applications)
 - what permissions user has granted to each application
 
+%package daemon-tests
+Summary: Tests files for %{name}-daemon
+
+%description daemon-tests
+%{summary}.
+
 %prep
 %setup -q -n %{name}-%{version}
 
@@ -77,6 +86,11 @@ make %{_smp_mflags} \
   _LIBDIR=%{_libdir}\
   _SHAREDSTATEDIR=%{_sharedstatedir}\
   -C daemon build
+
+make %{_smp_mflags} \
+  VERSION=%{version}\
+  TESTSDIR=%{_testsdir}\
+  -C daemon test-build
 
 %install
 rm -rf %{buildroot}
@@ -95,6 +109,12 @@ make \
   _SHAREDSTATEDIR=%{_sharedstatedir}\
   DESTDIR=%{buildroot}\
   -C daemon install
+
+make %{_smp_mflags} \
+  VERSION=%{version}\
+  DESTDIR=%{buildroot}\
+  TESTSDIR=%{_testsdir}\
+  -C daemon test-install
 
 install -d %{buildroot}%{_unitdir}/multi-user.target.wants
 install -m644 daemon/systemd/sailjaild.service %{buildroot}%{_unitdir}
@@ -135,3 +155,8 @@ make HAVE_FIREJAIL=%{jailfish} -C unit test
 %dir %{_sysconfdir}/sailjail
 %dir %{_sysconfdir}/sailjail/config
 %dir %{_sysconfdir}/sailjail/applications
+
+%files daemon-tests
+%defattr(-,root,root,-)
+%license COPYING
+%{_testsdir}/%{name}-daemon


### PR DESCRIPTION
This implements a minimal set of unit tests that checks some of the
functionality in sailjaild. It should provide enough framework to expand
the tests later to cover all aspects of sailjaild. There is support for
running tests without installing and generating coverage reports for
ease of development.

Also a fix to util/strip function that was discovered to be a bit broken 
and also included support for building without libdbusaccess from #47.

There are convenience make commands to run tests locally without installing anything:
```bash
make -C daemon/test/ run       # Just build and run tests
make -C daemon/test/ coverage  # Build, run and create coverage reports
make -C daemon/test/ clean     # Clean up
```
However the main way to run these tests is automatic testing (see tests.xml.in).