### PR TITLE
Read default profile from configuration

### DIFF
--- a/daemon/.depend
+++ b/daemon/.depend
@@ -38,12 +38,14 @@ config.o:\
 	config.c\
 	config.h\
 	logging.h\
+	stringset.h\
 	util.h\
 
 config.pic.o:\
 	config.c\
 	config.h\
 	logging.h\
+	stringset.h\
 	util.h\
 
 control.o:\

--- a/daemon/.depend
+++ b/daemon/.depend
@@ -2,6 +2,7 @@ appinfo.o:\
 	appinfo.c\
 	appinfo.h\
 	applications.h\
+	config.h\
 	control.h\
 	logging.h\
 	stringset.h\
@@ -11,6 +12,7 @@ appinfo.pic.o:\
 	appinfo.c\
 	appinfo.h\
 	applications.h\
+	config.h\
 	control.h\
 	logging.h\
 	stringset.h\
@@ -179,6 +181,7 @@ service.o:\
 	session.h\
 	settings.h\
 	stringset.h\
+	util.h\
 
 service.pic.o:\
 	service.c\
@@ -193,6 +196,7 @@ service.pic.o:\
 	session.h\
 	settings.h\
 	stringset.h\
+	util.h\
 
 session.o:\
 	session.c\

--- a/daemon/appinfo.h
+++ b/daemon/appinfo.h
@@ -76,6 +76,7 @@ gchar     *appinfo_to_string (const appinfo_t *self);
 
 bool            appinfo_valid       (const appinfo_t *self);
 control_t      *appinfo_control     (const appinfo_t *self);
+const config_t *appinfo_config      (const appinfo_t *self);
 applications_t *appinfo_applications(const appinfo_t *self);
 const gchar    *appinfo_id          (const appinfo_t *self);
 

--- a/daemon/applications.c
+++ b/daemon/applications.c
@@ -87,6 +87,7 @@ void            applications_rethink  (applications_t *self);
 control_t         *applications_control  (const applications_t *self);
 const stringset_t *applications_available(applications_t *self);
 appinfo_t         *applications_appinfo  (applications_t *self, const char *appname);
+const config_t    *applications_config   (const applications_t *self);
 
 /* ------------------------------------------------------------------------- *
  * APPLICATIONS_NOTIFY
@@ -240,13 +241,11 @@ applications_appinfo(applications_t *self, const char *appname)
     return appinfo_valid(appinfo) ? appinfo : NULL;
 }
 
-#ifdef DEAD_CODE
-static const config_t *
+const config_t *
 applications_config(const applications_t *self)
 {
     return control_config(applications_control(self));
 }
-#endif
 
 /* ========================================================================= *
  * APPLICATIONS_NOTIFY

--- a/daemon/applications.h
+++ b/daemon/applications.h
@@ -72,6 +72,7 @@ void            applications_rethink  (applications_t *self);
 control_t         *applications_control  (const applications_t *self);
 const stringset_t *applications_available(applications_t *self);
 appinfo_t         *applications_appinfo  (applications_t *self, const char *appname);
+const config_t    *applications_config   (const applications_t *self);
 
 G_END_DECLS
 

--- a/daemon/config.c
+++ b/daemon/config.c
@@ -37,6 +37,7 @@
 #include "config.h"
 
 #include "util.h"
+#include "stringset.h"
 #include "logging.h"
 
 #include <glob.h>
@@ -46,6 +47,7 @@
  * ========================================================================= */
 
 typedef struct config_t config_t;
+typedef struct stringset_t stringset_t;
 
 /* ========================================================================= *
  * Prototypes
@@ -73,9 +75,10 @@ static void config_load  (config_t *self);
  * CONFIG_VALUE
  * ------------------------------------------------------------------------- */
 
-bool   config_boolean(const config_t *self, const gchar *sec, const gchar *key, bool def);
-gint   config_integer(const config_t *self, const gchar *sec, const gchar *key, gint def);
-gchar *config_string (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+bool         config_boolean  (const config_t *self, const gchar *sec, const gchar *key, bool def);
+gint         config_integer  (const config_t *self, const gchar *sec, const gchar *key, gint def);
+gchar       *config_string   (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+stringset_t *config_stringset(const config_t *self, const gchar *sec, const gchar *key);
 
 /* ========================================================================= *
  * CONFIG
@@ -177,4 +180,10 @@ config_string(const config_t *self, const gchar *sec, const gchar *key,
               const gchar *def)
 {
     return keyfile_get_string(self->cfg_keyfile, sec, key, def);
+}
+
+stringset_t *
+config_stringset(const config_t *self, const gchar *sec, const gchar *key)
+{
+    return keyfile_get_stringset(self->cfg_keyfile, sec, key);
 }

--- a/daemon/config.h
+++ b/daemon/config.h
@@ -47,6 +47,7 @@ G_BEGIN_DECLS
  * ========================================================================= */
 
 typedef struct config_t config_t;
+typedef struct stringset_t stringset_t;
 
 /* ========================================================================= *
  * Prototypes
@@ -65,9 +66,10 @@ void      config_delete_cb(void *self);
  * CONFIG_VALUE
  * ------------------------------------------------------------------------- */
 
-bool   config_boolean(const config_t *self, const gchar *sec, const gchar *key, bool def);
-gint   config_integer(const config_t *self, const gchar *sec, const gchar *key, gint def);
-gchar *config_string (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+bool         config_boolean  (const config_t *self, const gchar *sec, const gchar *key, bool def);
+gint         config_integer  (const config_t *self, const gchar *sec, const gchar *key, gint def);
+gchar       *config_string   (const config_t *self, const gchar *sec, const gchar *key, const gchar *def);
+stringset_t *config_stringset(const config_t *self, const gchar *sec, const gchar *key);
 
 G_END_DECLS
 


### PR DESCRIPTION
When application doesn't define application profile, read default
profile from configuration file. Currently default profile allows only 
to define list of permissions that shall be used when sandboxing.

This doesn't yet implement sandboxing without default profile but
instead affects only what permissions sailjaild will report for apps
when application doesn't define them.

The configuration file looks something like this:
```ini
# /etc/sailjail/config/50-default-profile.conf
[Default Profile]
Permissions=Audio;Internet;UserDirs
```
(obviously a real configuration file would define more permissions)