### PR TITLE
React to application and session changes

### DIFF
--- a/daemon/prompter.h
+++ b/daemon/prompter.h
@@ -65,6 +65,7 @@ void        prompter_delete              (prompter_t *self);
 void        prompter_delete_at           (prompter_t **pself);
 void        prompter_delete_cb           (void *self);
 void        prompter_applications_changed(prompter_t *self, const stringset_t *changed);
+void        prompter_session_changed     (prompter_t *self);
 
 /* ------------------------------------------------------------------------- *
  * PROMPTER_INVOCATION

--- a/daemon/prompter.h
+++ b/daemon/prompter.h
@@ -48,8 +48,9 @@ G_BEGIN_DECLS
 typedef struct appinfo_t      appinfo_t;
 typedef struct service_t      service_t;
 typedef struct applications_t applications_t;
-typedef struct prompter_t prompter_t;
+typedef struct prompter_t     prompter_t;
 typedef struct control_t      control_t;
+typedef struct stringset_t    stringset_t;
 
 /* ========================================================================= *
  * Prototypes
@@ -59,10 +60,11 @@ typedef struct control_t      control_t;
  * PROMPTER
  * ------------------------------------------------------------------------- */
 
-prompter_t *prompter_create   (service_t *service);
-void        prompter_delete   (prompter_t *self);
-void        prompter_delete_at(prompter_t **pself);
-void        prompter_delete_cb(void *self);
+prompter_t *prompter_create              (service_t *service);
+void        prompter_delete              (prompter_t *self);
+void        prompter_delete_at           (prompter_t **pself);
+void        prompter_delete_cb           (void *self);
+void        prompter_applications_changed(prompter_t *self, const stringset_t *changed);
 
 /* ------------------------------------------------------------------------- *
  * PROMPTER_INVOCATION

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -973,4 +973,6 @@ service_applications_changed(service_t *self, const stringset_t *changed)
         }
         service_dbus_emit_signal(self, member, app);
     }
+
+    prompter_applications_changed(service_prompter(self), changed);
 }


### PR DESCRIPTION
Adjust invocation checks so that they can be used to check if invocation
has become resolvable and send a reply if that's the case. Handle error
cases more accurately.

Add change notifier for changed applications or application settings
changes to prompter. If some change resolves current invocation or items
in the queue they are replied immediately. Also cancel windowprompt when
current invocation is resolved.

Add change notify for session changes to prompter so that it can flush
all remaining invocations when that happens and disconnect from session
bus in case that was left connected.