### PR TITLE
[sailjail] Fix missing privileged group on executable. JB#54742

### DIFF
--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -17,6 +17,7 @@ Requires: xdg-dbus-proxy
 Provides: sailjail-launch-approval
 %endif
 Requires: sailjail-permissions
+Requires(pre): sailfish-setup
 
 Requires: glib2 >= %{glib_version}
 Requires: libglibutil >= %{libglibutil_version}


### PR DESCRIPTION
"privileged" group must be available before package installation to be
able to make executable owned by this group.