### PR TITLE
Update documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@ unit/coverage/*.gcov
 *.o
 *.core
 /daemon/sailjaild
+/daemon/sailjail
+/daemon/sailjailclient
 /daemon/test/test_appinfo
 /daemon/test/test_permissions
 /daemon/test/test_settings
@@ -14,3 +16,5 @@ unit/coverage/*.gcov
 /daemon/test/sailjail/permissions/
 /report/
 /coverage
+*.list
+/RPMS/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # Sailjail
 
-Sailfish OS application sandboxes are launched through Sailjail that is a thin Firejail wrapper. The Firejail documentation can be found from [here](https://firejail.wordpress.com/).
+Sailfish OS application sandboxes are launched through **sailjail** command that is a thin Firejail
+wrapper. Sailjail has also a daemon that manages sandboxing permissions and keeps a list of
+applications. Firejail documentation can be found [here](https://firejail.wordpress.com/).
 
-In this document we are following terminology defined by the Firejail.
+In this document we are following terminology defined by Firejail.
 
 ## Application permissions
 
@@ -53,14 +55,12 @@ the names differ you may define the desktop file with **sailjail** command's **-
 Use of absolute paths is required, except for the desktop file which must be located in
 _/usr/share/applications_ or _/etc/sailjail/applications_.
 
-## Homescreen integration
-The Sailjail package contains sailjail-plugin-devel subpackage that provides interfaces for building homescreen integration plugins. The idea is that plugin adds launching hooks and Sailjail triggers a hook to confirm the launch. The plugin in turn replies by denying or accepting the application launch. In case the plugin replies that permissions are not granted (i.e. are denied) Sailjail refuses to start the application.
+## Sailjail daemon
 
-Sailfish OS implements a homescreen integration plugin. Application permission are requested from user upon first application launch and accepted permissions are stored to root readable directory under */var/lib/sailjail-homescreen/\<uid\>/\<full-desktop-file-path\>/X-Sailjail*. Subsequent application launches do not re-trigger the permission request.
-
-When an application is upgraded and new permissions are introduced, permissions are requested again from the user. If permissions are removed from the application during upgrade, already approved permissions are considered sufficient and an intersection of permissions defined in the application desktop file and approved permissions are applied to the application.
-
-When going forward we are working towards more dynamic permission management system. Requested application permissions are visible in Settings -> Apps -> Application when application is sandboxed.
+Sailjail has a daemon called sailjaild. It keeps track of applications' desktop files in
+_/usr/share/applications_ and _/etc/sailjail/applications_. It can be queried over D-Bus for
+information regarding these applications, their sandboxing status and permissions. The daemon also
+handles prompting user for permissions.
 
 ## Sailfish OS specific changes to Firejail
 

--- a/README.md
+++ b/README.md
@@ -57,29 +57,21 @@ When going forward we are working towards more dynamic permission management sys
 
 ### Handling privileged user data
 
-In Sailfish OS portion of user data is considered private and although it resides within
-user's home directory the files / directories are owned by "privileged" user / group
-and only select applications are granted access via executing them with effective
-group id set to "privileged." For sandboxed applications "private-data \<directory\>"
-Firejail directive / command line option is used to provide more fine grained access
-to privileged data.
+In Sailfish OS portion of user data is considered private and although it resides within user's home
+directory the files / directories are owned by _privileged_ user / group and only select
+applications are granted access via executing them with effective group id set to _privileged_. For
+sandboxed applications _private-data \<directory\>_ Firejail rule or command line option is used to
+provide more fine grained access to privileged data.
 
-Also noteworthy: sandboxed applications are executed with no-new-privs set. As this
-makes it impossible to have effective gid that differs from real gid, privileged applications
-are running with real group id set to "privileged".
+Also noteworthy: sandboxed applications are executed with _no-new-privs_ set. As this makes it
+impossible to have effective gid that differs from real gid, privileged applications are running
+with real group id set to _privileged_.
 
 ### General fixes that might be eligible for upstreaming
 
-- "mkdir \<path\>" and "mkfile \<path\>"  are available also as command line options
-  (normally available only as profile file directives).
-- "protocol \<list\>" can be adjusted multiple times (original set-once logic made
-   incremental configuration impossible).
-- Symlinks that go through /proc/self are retargeted during sandbox setup (was
-  causing problems with e.g. /etc/mtab which is symlink to ../proc/self/mounts).
-- Bind mounted passwd/group files that are used during sandbox setup are
-  unmounted before private-etc is taken in use (leaving such bind mounts active
-  under synthetized /etc was causing problems in many phones  due to use of
-  relatively old kernel versions).
+- Rule templating. Sailjail defines keywords used in Firejail profiles that Firejail substitutes
+  automatically while parsing the rules.
+- Loading profiles only after parsing arguments instead of loading while parsing.
 
 ## Debugging sandboxed applications
 

--- a/README.md
+++ b/README.md
@@ -8,23 +8,30 @@ In this document we are following terminology defined by Firejail.
 
 ## Application permissions
 
-Application [permissions](https://github.com/sailfishos/sailjail-permissions#sailfish-os-application-sandboxing-and-permissions) defined in Sailjail-permissions are Firejail profiles. Application developer defines set of required permissions in the application desktop file.
+Application
+[permissions](https://github.com/sailfishos/sailjail-permissions#sailfish-os-application-sandboxing-and-permissions)
+defined in [sailjail-permissions](https://github.com/sailfishos/sailjail-permissions) are Firejail
+profiles. Application developer defines set of required permissions in the application desktop file.
 
-Application desktop file changes are described in the [Sailjail Permissions documentation](https://github.com/sailfishos/sailjail-permissions#enable-sandboxing-for-an-application).
+Application desktop file changes are described in the [Sailjail Permissions
+documentation](https://github.com/sailfishos/sailjail-permissions#enable-sandboxing-for-an-application).
 
-Sailjail parses the permissions and builds Firejail command line arguments out of the requested permissions.
+Sailjail parses the desktop file and builds Firejail command line arguments out of the requested
+permissions.
 
 ## Application data structure
 
-There are three directories that are whitelisted automatically by the Sailjail based on the
-desktop file definition.
+There are three directories that are whitelisted automatically by Sailjail based on desktop file
+content.
 
     $HOME/.local/share/<OrganizationName>/<ApplicationName>
     $HOME/.cache/<OrganizationName>/<ApplicationName>
     $HOME/.config/<OrganizationName>/<ApplicationName>
 
-
-Default user data directories such as [*Pictures*, *Videos*, *Music*, *Documents*](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) are not whitelisted by default rather application developer needs to request access with predefined [Permissions](https://github.com/sailfishos/sailjail-permissions#permissions).
+Default user data directories such as [*Pictures*, *Videos*, *Music* and
+*Documents*](https://www.freedesktop.org/wiki/Software/xdg-user-dirs/) are not whitelisted by
+default rather application developer needs to request access with predefined
+[permissions](https://github.com/sailfishos/sailjail-permissions#permissions).
 
 ## Implicit D-Bus user service ownership
 

--- a/README.md
+++ b/README.md
@@ -26,25 +26,34 @@ Default user data directories such as [*Pictures*, *Videos*, *Music*, *Documents
 
 ## Implicit D-Bus user service ownership
 
-Based on the [*OrganizationName* and *ApplicationName*](https://github.com/sailfishos/sailjail-permissions#desktop-file-changes) application is granted rights to own its D-Bus user service.
+Based on [*OrganizationName* and
+*ApplicationName* values](https://github.com/sailfishos/sailjail-permissions#desktop-file-changes)
+application is granted rights to own a D-Bus service name on user session bus.
 
 Example desktop file
 
     [Desktop Entry]
     Type=Application
-    Name=MyApplication
+    Name=My Application
     Icon=my-app-icon
-    Exec=/usr/bin/sailjail -p org.foobar.myapp.desktop /usr/bin/org.foobar.myapp
+    Exec=/usr/bin/org.foobar.MyApp
+
     [X-Sailjail]
     Permissions=Internet;Pictures
     OrganizationName=org.foobar
-    ApplicationName=myapp
+    ApplicationName=MyApp
 
-With above example application desktop file Firejail command line arguments contain implicitly *--dbus-user.own=org.foobar.myapp* when launched through Sailjail.
-Use of absolute paths is required, except for the desktop file if it is located in /usr/share/applications which is also required by homescreen integration in most cases.
+With above example application desktop file Firejail command line arguments contain implicitly
+**--dbus-user.own=org.foobar.MyApp** when launched through Sailjail.
+When application's executable matches desktop file name, it is enough to define it in Exec value. If
+the names differ you may define the desktop file with **sailjail** command's **-p** argument:
+
+    Exec=/usr/bin/sailjail -p foobar-myapp.desktop -- /usr/bin/org.foobar.MyApp
+
+Use of absolute paths is required, except for the desktop file which must be located in
+_/usr/share/applications_ or _/etc/sailjail/applications_.
 
 ## Homescreen integration
-
 The Sailjail package contains sailjail-plugin-devel subpackage that provides interfaces for building homescreen integration plugins. The idea is that plugin adds launching hooks and Sailjail triggers a hook to confirm the launch. The plugin in turn replies by denying or accepting the application launch. In case the plugin replies that permissions are not granted (i.e. are denied) Sailjail refuses to start the application.
 
 Sailfish OS implements a homescreen integration plugin. Application permission are requested from user upon first application launch and accepted permissions are stored to root readable directory under */var/lib/sailjail-homescreen/\<uid\>/\<full-desktop-file-path\>/X-Sailjail*. Subsequent application launches do not re-trigger the permission request.


### PR DESCRIPTION
Add brief documentation about sailjail daemon to README.md. Remove
the chapter about homescreen intergration as it's outdated.

Add some formatting fixes to changes for privileged data access.

Update documentation regarding firejail changes.
Remove already upstreamed firejail changes and add those that have not
yet been sent.

Update chapter about D-Bus user service ownership.
Make the example a little bit more up to date by not using sailjail
command on Exec line and using capitalized version of application name.
Also update the text about absolute paths.

Format all lines to 100 characters when possible. Adjust some wordings.

Add missing files to .gitignore.