### PR TITLE
[sailjail] Generate DBus service files for sandboxed applications. Fixes JB#54966 OMP#JOLLA-253

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Example desktop file
     Permissions=Internet;Pictures
     OrganizationName=org.foobar
     ApplicationName=MyApp
+    ExecDBus=/usr/bin/org.foobar.MyApp -prestart
 
 With above example application desktop file Firejail command line arguments contain implicitly
 **--dbus-user.own=org.foobar.MyApp** when launched through Sailjail.
@@ -61,6 +62,9 @@ the names differ you may define the desktop file with **sailjail** command's **-
 
 Use of absolute paths is required, except for the desktop file which must be located in
 _/usr/share/applications_ or _/etc/sailjail/applications_.
+
+The ExecDBus value is an optional command line which will be used to auto start the application
+to provide the <OrganizationName>.<ApplicationName> DBus service.
 
 ## Sailjail daemon
 

--- a/daemon/appinfo.h
+++ b/daemon/appinfo.h
@@ -85,6 +85,7 @@ control_t      *appinfo_control     (const appinfo_t *self);
 const config_t *appinfo_config      (const appinfo_t *self);
 applications_t *appinfo_applications(const appinfo_t *self);
 const gchar    *appinfo_id          (const appinfo_t *self);
+bool            appinfo_dbus_auto_start(const appinfo_t *self);
 
 /* ------------------------------------------------------------------------- *
  * APPINFO_PROPERTY
@@ -100,6 +101,7 @@ const gchar *appinfo_get_object           (const appinfo_t *self);
 const gchar *appinfo_get_method           (const appinfo_t *self);
 const gchar *appinfo_get_organization_name(const appinfo_t *self);
 const gchar *appinfo_get_application_name (const appinfo_t *self);
+const gchar *appinfo_get_exec_dbus        (const appinfo_t *self);
 const gchar *appinfo_get_data_directory   (const appinfo_t *self);
 app_mode_t   appinfo_get_mode             (const appinfo_t *self);
 void         appinfo_set_name             (appinfo_t *self, const gchar *name);
@@ -112,6 +114,7 @@ void         appinfo_set_object           (appinfo_t *self, const gchar *object)
 void         appinfo_set_method           (appinfo_t *self, const gchar *method);
 void         appinfo_set_organization_name(appinfo_t *self, const gchar *organization_name);
 void         appinfo_set_application_name (appinfo_t *self, const gchar *application_name);
+void         appinfo_set_exec_dbus        (appinfo_t *self, const gchar *exec_dbus);
 void         appinfo_set_data_directory   (appinfo_t *self, const gchar *data_directory);
 void         appinfo_set_mode             (appinfo_t *self, app_mode_t mode);
 

--- a/daemon/appservices.c
+++ b/daemon/appservices.c
@@ -1,0 +1,476 @@
+/*
+ * Copyright (c) 2021 Open Mobile Platform LLC.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer
+ *      in the documentation and/or other materials provided with the
+ *      distribution.
+ *   3. Neither the names of the copyright holders nor the names of its
+ *      contributors may be used to endorse or promote products derived
+ *      from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * The views and conclusions contained in the software and documentation
+ * are those of the authors and should not be interpreted as representing
+ * any official policies, either expressed or implied.
+ */
+
+# include "appservices.h"
+
+# include "appinfo.h"
+# include "applications.h"
+# include "control.h"
+# include "session.h"
+# include "stringset.h"
+# include "util.h"
+# include "logging.h"
+
+# include <glob.h>
+# include <linux/limits.h>
+# include <pwd.h>
+# include <stdio.h>
+# include <sys/stat.h>
+# include <unistd.h>
+
+/* ========================================================================= *
+ * Types
+ * ========================================================================= */
+
+typedef struct serviceinfo_t
+{
+    char *name;
+    char *exec;
+} serviceinfo_t;
+
+/* ========================================================================= *
+ * Prototypes
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * APPSERVICES
+ * ------------------------------------------------------------------------- */
+
+static void    appservices_ctor                (appservices_t *self, control_t *control);
+static void    appservices_dtor                (appservices_t *self);
+appservices_t *appservices_create              (control_t *control);
+void           appservices_delete              (appservices_t *self);
+void           appservices_delete_at           (appservices_t **pself);
+void           appservices_delete_cb           (void *self);
+void           appservices_rethink             (appservices_t *self);
+void           appservices_application_changed (appservices_t *self, const char *appname, appinfo_t *appinfo);
+void           appservices_application_added   (appservices_t *self, const char *appname, appinfo_t *appinfo);
+void           appservices_application_removed (appservices_t *self, const char *appname);
+
+static void  appservices_update_user          (appservices_t *self);
+static bool  appservices_ensure_run_directory(appservices_t *self, const char *directory);
+static char *appservices_service_filename     (appservices_t *self, const char *service);
+static void  appservices_write_service_file   (appservices_t *self, const char *appname, appinfo_t *appinfo);
+static void  appservices_remove_service_file  (appservices_t *self, const char *appname);
+
+
+/* ------------------------------------------------------------------------- *
+ * SERVICEINFO
+ * ------------------------------------------------------------------------- */
+
+static serviceinfo_t *serviceinfo_create(const char *name, const char *exec);
+static void           serviceinfo_delete(serviceinfo_t *self);
+static void           serviceinfo_delete_cb(void *self);
+
+/* ------------------------------------------------------------------------- *
+ * APPSERVICES
+ * ------------------------------------------------------------------------- */
+
+struct appservices_t
+{
+    control_t       *asv_control;
+    GHashTable      *asv_service_lut;
+    char            *asv_run_dir;
+    uid_t            asv_uid;
+    gid_t            asv_gid;
+};
+
+static void
+appservices_ctor(appservices_t *self, control_t *control)
+{
+    log_info("appservices() create");
+
+    self->asv_control = control;
+    self->asv_uid = SESSION_UID_UNDEFINED;
+    self->asv_gid = SESSION_GID_UNDEFINED;
+
+    self->asv_service_lut = g_hash_table_new_full(g_str_hash,
+                                                  g_str_equal,
+                                                  g_free,
+                                                  serviceinfo_delete_cb);
+    appservices_rethink(self);
+}
+
+static void
+appservices_dtor(appservices_t *self)
+{
+    log_info("appservices() delete");
+
+    g_free(self->asv_run_dir);
+    self->asv_run_dir = NULL;
+
+    if( self->asv_service_lut ) {
+        g_hash_table_unref(self->asv_service_lut),
+            self->asv_service_lut = NULL;
+    }
+}
+
+appservices_t *
+appservices_create(control_t *control)
+{
+    appservices_t *self = g_malloc0(sizeof *self);
+    appservices_ctor(self, control);
+    return self;
+}
+
+void
+appservices_delete(appservices_t *self)
+{
+    if( self ) {
+        appservices_dtor(self);
+        g_free(self);
+    }
+}
+
+void
+appservices_delete_at(appservices_t **pself)
+{
+    appservices_delete(*pself), *pself = NULL;
+}
+
+void
+appservices_delete_cb(void *self)
+{
+    appservices_delete(self);
+}
+
+void
+appservices_rethink(appservices_t *self)
+{
+    appservices_update_user(self);
+
+    if( !self->asv_run_dir ) {
+        return;
+    }
+
+    /* Repopulate the services table with the services from the current users run directory */
+    g_hash_table_remove_all(self->asv_service_lut);
+
+    stringset_t *appnames_to_remove = stringset_create();
+    char *pattern = g_strdup_printf("%s" DBUS_SERVICES_DIRECTORY
+                                    "/" DBUS_SERVICES_PATTERN,
+                                    self->asv_run_dir);
+    glob_t gl  = {};
+
+    if( glob(pattern, 0, 0, &gl) == 0 ) {
+        for( int i = 0; i < gl.gl_pathc; ++i ) {
+            GKeyFile *keyfile = g_key_file_new();
+            if( keyfile_load(keyfile, gl.gl_pathv[i]) ) {
+                char *name = g_key_file_get_string(keyfile,
+                                                   DBUS_SERVICE_SECTION,
+                                                   DBUS_KEY_NAME,
+                                                   NULL);
+                char *exec = g_key_file_get_string(keyfile,
+                                                   DBUS_SERVICE_SECTION,
+                                                   DBUS_KEY_EXEC,
+                                                   NULL);
+                char *appname = g_key_file_get_string(keyfile,
+                                                      DBUS_SERVICE_SECTION,
+                                                      DBUS_KEY_APPLICATION,
+                                                      NULL);
+                if( name && exec && appname ) {
+                    stringset_add_item(appnames_to_remove, appname);
+                    g_hash_table_replace(self->asv_service_lut, appname,
+                                         serviceinfo_create(name, exec));
+                }
+                else {
+                    g_free(appname);
+                }
+
+                g_free(name);
+                g_free(exec);
+            }
+            g_key_file_unref(keyfile);
+        }
+    }
+
+    globfree(&gl);
+    g_free(pattern);
+
+    /* Add the current set of applications */
+    applications_t *applications = control_applications(self->asv_control);
+
+    gchar **appnames = stringset_to_strv(applications_available(applications));
+
+    for( guint i = 0; appnames[i]; ++i ) {
+        char *appname = appnames[i];
+
+        appinfo_t *appinfo = applications_appinfo(applications, appname);
+
+        if( appinfo && appinfo_dbus_auto_start(appinfo) ) {
+            stringset_remove_item(appnames_to_remove, appname);
+
+            appservices_write_service_file(self, appname, appinfo);
+        }
+    }
+
+    g_strfreev(appnames);
+
+    /* Remove any service files that weren't matched to an application. */
+    appnames = stringset_to_strv(appnames_to_remove);
+    for( guint i = 0; appnames[i]; ++i ) {
+        appservices_remove_service_file(self, appnames[i]);
+    }
+    g_strfreev(appnames);
+    stringset_delete(appnames_to_remove);
+}
+
+void
+appservices_application_changed(appservices_t *self, const char *appname, appinfo_t *appinfo)
+{
+    if( appinfo_dbus_auto_start(appinfo) ) {
+        appservices_write_service_file(self, appname, appinfo);
+    }
+    else {
+        appservices_remove_service_file(self, appname);
+    }
+}
+
+void
+appservices_application_added(appservices_t *self, const char *appname, appinfo_t *appinfo)
+{
+    if( appinfo_dbus_auto_start(appinfo) ) {
+        appservices_write_service_file(self, appname, appinfo);
+    }
+}
+
+void
+appservices_application_removed(appservices_t *self, const char *appname)
+{
+    appservices_remove_service_file(self, appname);
+}
+
+void
+appservices_update_user(appservices_t *self)
+{
+    uid_t uid = control_current_user(self->asv_control);
+
+    if( self->asv_uid != uid ) {
+        self->asv_uid = uid;
+        self->asv_gid = SESSION_GID_UNDEFINED;
+
+        g_free(self->asv_run_dir);
+        self->asv_run_dir = NULL;
+
+        /* Get the gid and run directory of the current user */
+        if( self->asv_uid != SESSION_UID_UNDEFINED ) {
+            long initlen = sysconf(_SC_GETPW_R_SIZE_MAX);
+            size_t len = 131072; // ARG_MAX;
+            if( initlen != -1 ) {
+                len = (size_t) initlen;
+            }
+
+            struct passwd result;
+            struct passwd *resultp;
+            char *buffer = malloc(len);
+
+            if( !getpwuid_r(self->asv_uid, &result, buffer, len, &resultp) ) {
+                self->asv_gid = result.pw_gid;
+                self->asv_run_dir = g_strdup_printf(RUNTIME_DATADIR "/%lld",
+                                                    (long long)uid);
+            }
+
+            free(buffer);
+        }
+
+        /* Verify the dbus services directory exists under run and create it if necessary
+           Note the default directory ownership is incorrect in this instance and needs to
+           be corrected for each subdirectory created */
+        if( self->asv_run_dir && (
+                    !appservices_ensure_run_directory(self, DBUS_DIRECTORY) ||
+                    !appservices_ensure_run_directory(self, DBUS_SERVICES_DIRECTORY))) {
+            g_free(self->asv_run_dir);
+            self->asv_run_dir = NULL;
+        }
+    }
+}
+
+bool
+appservices_ensure_run_directory(appservices_t *self, const char *directory)
+{
+    char *path = g_strdup_printf("%s%s", self->asv_run_dir, directory);
+
+    bool exists = !access(path, F_OK);
+
+    if( !exists ) {
+        if( mkdir(path, 0700) ) {
+            log_warning("appservices() could not create directory %s: %m", path);
+        }
+        else if( chown(path, self->asv_uid, self->asv_gid) ) {
+            log_warning("appservices() could not change ownership of directory %s: %m", path);
+
+            unlink(path);
+        }
+        else {
+            exists = true;
+        }
+    }
+
+    g_free(path);
+
+    return exists;
+}
+
+char *
+appservices_service_filename (appservices_t *self, const char *service)
+{
+    return g_strdup_printf("%s" DBUS_SERVICES_DIRECTORY
+                           "/%s" DBUS_SERVICES_EXTENSION,
+                           self->asv_run_dir, service);
+}
+
+void
+appservices_write_service_file(appservices_t *self, const char *appname, appinfo_t *appinfo)
+{
+    if( !self->asv_run_dir ) {
+        return;
+    }
+
+    bool changed = false;
+    char *service_name = g_strdup_printf("%s.%s",
+                                         appinfo_get_organization_name(appinfo),
+                                         appinfo_get_application_name(appinfo));
+    const char *exec = appinfo_get_exec_dbus(appinfo);
+
+    /* If the service name for application has changed remove any existing service file */
+    const serviceinfo_t *current_service = g_hash_table_lookup(self->asv_service_lut, appname);
+    if( current_service && strcmp(service_name, current_service->name) ) {
+        char *service_filename = appservices_service_filename(self, current_service->name);
+        log_info("appservices(%s) remove service file %s", appname, service_filename);
+        unlink(service_filename);
+        g_free(service_filename);
+
+        changed = true;
+    }
+    /* If the existing name and executable are unchanged do nothing */
+    else if( current_service && !strcmp(exec, current_service->exec)) {
+        g_free(service_name);
+
+        return;
+    }
+
+    /* Populate a new service file */
+    GKeyFile *keyfile = g_key_file_new();
+
+    keyfile_set_string(keyfile, DBUS_SERVICE_SECTION, DBUS_KEY_NAME, service_name);
+    keyfile_set_string(keyfile, DBUS_SERVICE_SECTION, DBUS_KEY_EXEC, exec);
+    keyfile_set_string(keyfile, DBUS_SERVICE_SECTION, DBUS_KEY_APPLICATION, appname);
+
+    char *service_filename = appservices_service_filename(self, service_name);
+
+    log_info("appservices(%s) write service file %s", appname, service_filename);
+
+    char *tmp_service_filename = g_strdup_printf("%s.tmp", service_filename);
+
+    /* Write the service file to disk making sure to fixup the ownership and permissions
+       as this is not running as the target user and a umask is set to protect settings files */
+    if( keyfile_save(keyfile, tmp_service_filename) ) {
+        if( chown(tmp_service_filename, self->asv_uid, self->asv_gid) ||
+                chmod(tmp_service_filename, 0644) ) {
+            log_warning("appservices() could not change ownership or permissions of file %s: %m", tmp_service_filename);
+
+            unlink(tmp_service_filename);
+        }
+        else {
+            rename(tmp_service_filename, service_filename);
+
+            changed = true;
+        }
+    }
+
+    g_key_file_unref(keyfile);
+
+    g_hash_table_replace(self->asv_service_lut, g_strdup(appname),
+                         serviceinfo_create(service_name, exec));
+
+    g_free(service_name);
+    g_free(service_filename);
+    g_free(tmp_service_filename);
+
+    if( changed ) {
+        control_on_appservices_change(self->asv_control);
+    }
+}
+
+void
+appservices_remove_service_file(appservices_t *self, const char *appname)
+{
+    if( !self->asv_run_dir ) {
+        return;
+    }
+
+    const serviceinfo_t *service = g_hash_table_lookup(self->asv_service_lut, appname);
+
+    if( service ) {
+        char *service_filename = appservices_service_filename(self, service->name);
+
+        log_info("appservices(%s) remove service file %s", appname, service_filename);
+
+        unlink(service_filename);
+        g_free(service_filename);
+
+        g_hash_table_remove(self->asv_service_lut, appname);
+
+        control_on_appservices_change(self->asv_control);
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * SERVICEINFO
+ * ------------------------------------------------------------------------- */
+
+serviceinfo_t *
+serviceinfo_create(const char *name, const char *exec)
+{
+    serviceinfo_t *self = g_malloc0(sizeof *self);
+    self->name = g_strdup(name);
+    self->exec = g_strdup(exec);
+    return self;
+}
+
+void
+serviceinfo_delete(serviceinfo_t *self)
+{
+    g_free(self->name);
+    g_free(self->exec);
+    g_free(self);
+}
+
+void
+serviceinfo_delete_cb(void *self)
+{
+    serviceinfo_delete(self);
+}

--- a/daemon/appservices.h
+++ b/daemon/appservices.h
@@ -34,26 +34,20 @@
  * any official policies, either expressed or implied.
  */
 
-#ifndef  SESSION_H_
-# define SESSION_H_
+#ifndef  APPSERVICES_H_
+# define APPSERVICES_H_
 
 # include <glib.h>
 
 G_BEGIN_DECLS
 
 /* ========================================================================= *
- * Constants
- * ========================================================================= */
-
-# define SESSION_UID_UNDEFINED ((uid_t)(-1))
-# define SESSION_GID_UNDEFINED ((gid_t)(-1))
-
-/* ========================================================================= *
  * Types
  * ========================================================================= */
 
-typedef struct config_t       config_t;
-typedef struct session_t      session_t;
+typedef struct stringset_t    stringset_t;
+typedef struct appservices_t  appservices_t;
+typedef struct appinfo_t      appinfo_t;
 typedef struct control_t      control_t;
 
 /* ========================================================================= *
@@ -61,20 +55,18 @@ typedef struct control_t      control_t;
  * ========================================================================= */
 
 /* ------------------------------------------------------------------------- *
- * SESSION
+ * APPSERVICES
  * ------------------------------------------------------------------------- */
 
-session_t *session_create   (control_t *control);
-void       session_delete   (session_t *self);
-void       session_delete_at(session_t **pself);
-void       session_delete_cb(void *self);
-
-/* ------------------------------------------------------------------------- *
- * SESSION_USER
- * ------------------------------------------------------------------------- */
-
-uid_t session_current_user(const session_t *self);
+appservices_t *appservices_create              (control_t *control);
+void           appservices_delete              (appservices_t *self);
+void           appservices_delete_at           (appservices_t **pself);
+void           appservices_delete_cb           (void *self);
+void           appservices_rethink             (appservices_t *self);
+void           appservices_application_changed (appservices_t *self, const char *appname, appinfo_t *appinfo);
+void           appservices_application_added   (appservices_t *self, const char *appname, appinfo_t *appinfo);
+void           appservices_application_removed (appservices_t *self, const char *appname);
 
 G_END_DECLS
 
-#endif /* SESSION_H_ */
+#endif /* APPSERVICES_H_ */

--- a/daemon/control.h
+++ b/daemon/control.h
@@ -57,6 +57,7 @@ typedef struct service_t      service_t;
 typedef struct appinfo_t      appinfo_t;
 typedef struct settings_t     settings_t;
 typedef struct appsettings_t  appsettings_t;
+typedef struct appservices_t  appservices_t;
 
 /* ========================================================================= *
  * Prototypes
@@ -82,6 +83,7 @@ permissions_t     *control_permissions           (const control_t *self);
 applications_t    *control_applications          (const control_t *self);
 service_t         *control_service               (const control_t *self);
 settings_t        *control_settings              (const control_t *self);
+appservices_t     *control_appservices           (const control_t *self);
 appsettings_t     *control_appsettings           (control_t *self, uid_t uid, const char *app);
 appinfo_t         *control_appinfo               (const control_t *self, const char *appname);
 uid_t              control_current_user          (const control_t *self);
@@ -103,6 +105,7 @@ void control_on_session_changed   (control_t *self);
 void control_on_permissions_change(control_t *self);
 void control_on_application_change(control_t *self, GHashTable *changed);
 void control_on_settings_change   (control_t *self, const char *app);
+void control_on_appservices_change(control_t *self);
 
 G_END_DECLS
 

--- a/daemon/meson.build
+++ b/daemon/meson.build
@@ -30,6 +30,7 @@ daemon_src = files([
   'sailjaild.c',
   'appinfo.c',
   'applications.c',
+  'appservices.c',
   'config.c',
   'control.c',
   'later.c',

--- a/daemon/prompter.h
+++ b/daemon/prompter.h
@@ -71,7 +71,8 @@ void        prompter_session_changed     (prompter_t *self);
  * PROMPTER_INVOCATION
  * ------------------------------------------------------------------------- */
 
-void prompter_handle_invocation(prompter_t *self, GDBusMethodInvocation *invocation);
+void prompter_handle_invocation (prompter_t *self, GDBusMethodInvocation *invocation);
+void prompter_dbus_reload_config(prompter_t *self);
 
 G_END_DECLS
 

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -46,6 +46,11 @@ G_BEGIN_DECLS;
  * DBUS
  * ========================================================================= */
 
+#define DBUS_SERVICE                           "org.freedesktop.DBus"
+#define DBUS_PATH                              "/"
+#define DBUS_INTERFACE                         "org.freedesktop.DBus"
+#define DBUS_METHOD_RELOAD_CONFIG              "ReloadConfig"
+
 # define WINDOWPROMT_SERVICE                   "com.jolla.windowprompt"
 # define WINDOWPROMT_OBJECT                    "/com/jolla/windowprompt"
 # define WINDOWPROMT_INTERFACE                 "com.jolla.windowprompt"

--- a/daemon/util.h
+++ b/daemon/util.h
@@ -67,6 +67,11 @@ G_BEGIN_DECLS
 #  define DATADIR                       "/usr/share"
 # endif
 
+# define RUNTIME_DATADIR                "/run/user"
+
+# define HOME_LOCALDIR                  "/.local"
+# define HOME_DATADIR                   HOME_LOCALDIR "/share"
+
 /* Config from: *.conf */
 # define CONFIG_DIRECTORY               SYSCONFDIR "/sailjail/config"
 # define CONFIG_EXTENSION               ".conf"
@@ -90,6 +95,12 @@ G_BEGIN_DECLS
 
 /* Sailjail overrides from: *.desktop */
 # define SAILJAIL_APP_DIRECTORY         SYSCONFDIR "/sailjail/applications"
+
+/* Writable DBus services */
+# define DBUS_DIRECTORY                 "/dbus-1"
+# define DBUS_SERVICES_DIRECTORY        DBUS_DIRECTORY "/services"
+# define DBUS_SERVICES_EXTENSION        ".service"
+# define DBUS_SERVICES_PATTERN          "*" DBUS_SERVICES_EXTENSION
 
 /* Settings from: *.settings */
 # define SETTINGS_DIRECTORY             SHAREDSTATEDIR "/sailjail/settings"
@@ -123,6 +134,7 @@ G_BEGIN_DECLS
 # define SAILJAIL_KEY_DATA_DIRECTORY    "DataDirectory"
 # define SAILJAIL_KEY_PERMISSIONS       "Permissions"
 # define SAILJAIL_KEY_SANDBOXING        "Sandboxing"
+# define SAILJAIL_KEY_EXEC_DBUS         "ExecDBus"
 
 # define NEMO_KEY_APPLICATION_TYPE      "X-Nemo-Application-Type"
 # define NEMO_KEY_SINGLE_INSTANCE       "X-Nemo-Single-Instance"
@@ -130,6 +142,12 @@ G_BEGIN_DECLS
 # define MAEMO_KEY_FIXED_ARGS           "X-Maemo-Fixed-Args"
 
 # define OSSO_KEY_SERVICE               "X-Osso-Service"
+
+/* DBus service file properties */
+# define DBUS_SERVICE_SECTION            "D-BUS Service"
+# define DBUS_KEY_NAME                   "Name"
+# define DBUS_KEY_EXEC                   "Exec"
+# define DBUS_KEY_APPLICATION            "X-Sailjail-Application"
 
 /* ========================================================================= *
  * Types

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -45,6 +45,8 @@ Contains a script to measure launching time.
 %package daemon
 Summary: Daemon for managing application sandboxing permissions
 
+Requires: mapplauncherd >= 4.2.8
+
 %description daemon
 This package contains daemon that keeps track of:
 - defined permissions (under /etc/sailjail/permissions)


### PR DESCRIPTION
If an application includes a DBusExec entry under the [X-Sailjail] group
create a DBus service file under $HOME/.local/share/dbus-1/services with
Exec=DBusExec and Name=OrganizationName.ApplicationName.