### PR TITLE
[sailjaild] Update daemon readme. Fixes JB#55063 OMP#JOLLA-281

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -1,5 +1,82 @@
+Sailjail Daemon
+===============
+
+This document briefly describes internal structure of sailjail daemon
+itself, and how / what kinds of clients it is expected to serve.
+
+Client Behavior
+===============
+
+Modifying Settings
+------------------
+
+Expectation is that direct manipulation of sandboxing related application
+data is limited to privileged applications such as Settings UI. This is
+enforced by checking credentials of clients making such method calls.
+
+Tracking known applications can be done by obtaining initial set of
+applications via GetApplications() method call and adjusting the active set
+when ApplicationAdded or ApplicationRemoved signals are received.
+
+System wide information about each application can be obtained via
+GetAppInfo() method call. This data originates from read-only configuration
+/ desktop / etc files and can be assumed to be fairly static. Still, if such
+information is cached long term, it should be refreshed upon receiving
+ApplicationChanged signal.
+
+User specific application settings can be obtained via:
+
+- GetLaunchAllowed()
+- GetGrantedPermissions()
+
+Privileged applications can modify these via:
+
+- SetLaunchAllowed()
+- SetGrantedPermissions()
+
+Also changes in user specific settings are reported via ApplicationChanged
+signal. In case of long term caching, client should refresh all settings for
+all users that are of interest to the client.
+
+Launching Applications
+----------------------
+
+Launchers are assumed to be fairly simple procedural programs that do not
+employ event based mainloop. To facilitate such behavior sailjail daemon has
+two helper methods that can be used to obtain launch permissions via a
+single blocking D-Bus calls:
+
+- PromptLaunchPermissions()
+- QueryLaunchPermissions()
+
+QueryLaunchPermissions() basically handles (within sailjail daemon)
+obtaining uid of the currently active user session [e.g. sd_seat_get_active()],
+checking whether that UID can launch application [GetLaunchAllowed()], and
+returns list of permissions the application has been granted
+[SetGrantedPermissions()] or error reply.
+
+PromptLaunchPermissions() behaves similarly, but in case application launch
+has not been explicitly allowed or denied, user is first prompted for launch
+permission. In such cases reply message is delayed until user responds to
+permission prompt and thus client should use either long or infinite timeout
+for the D-Bus method call.
+
+Sandboxed Application
+---------------------
+
+Expectation is that applications do not need to do IPC with sailjail daemon,
+and in case of normal application launch it is not even possible as sailjail
+D-Bus service is not visible from within sandbox.
+
+In case application has been lauched via application specific sandboxed
+booster, portion of sailjail D-Bus interface relevant to boosting logic
+is available but applications should not rely on that.
+
+Daemon Internals
+================
+
 Existing User Tracking
-======================
+----------------------
 
 - tracking is done by:
   - monitoring /etc/passwd file
@@ -16,7 +93,7 @@ Existing User Tracking
   - user must be dropped from settings data
 
 User Session Tracking
-=====================
+---------------------
 
 - tracks UID of current user
 
@@ -27,7 +104,7 @@ User Session Tracking
   - cancels pending/queued prompts
 
 Permission File Tracking
-========================
+------------------------
 
 - tracking is done by:
   - monitoring /etc/sailjail/permissions directory
@@ -39,15 +116,35 @@ Permission File Tracking
   - triggers application data re-evaluation
 
 Desktop File Tracking
-=====================
+---------------------
 
-- tracking is done by:
-  - monitoring /usr/share/applications directory
+- tracking is done by monitoring *.desktop files in directories:
+  - /usr/share/applications
+    - regular desktop files
+    - optionally with sailjail specific section
+  - /etc/sailjail/applications
+    - uses desktop file format
+    - can be used for defining permissions for ui-less applications
+    - or augmenting / overriding values from /usr/share/applications
 
 - maintained data:
   - set of APPLICATION data, each with:
-    - Desktop properties: Name, Type, Exec, Icon
-    - Sailjail properties: Permissions
+    - [Desktop Entry] properties:
+      - Name
+      - Type
+      - Exec
+      - Icon
+      - NoDisplay
+      - X-Maemo-Service
+      - X-Maemo-Object-Path
+      - X-Maemo-Method
+    - [Sailjail] properties:
+      - Permissions
+      - OrganizationName
+      - ApplicationName
+      - DataDirectory
+      - Sandboxing
+      - ExecDBus
 
 - APPLICATION added:
   - broadcast ApplicationAdded signal
@@ -76,7 +173,7 @@ Desktop File Tracking
       - changes in user settings data
 
 User / Application Settings
-===========================
+---------------------------
 
 - maintained data:
   - tree of: settings(1) -> users(n) -> applications (n)
@@ -123,12 +220,21 @@ User / Application Settings
     - values: UNSET=0|YES=1|NO=2
     - used only for: "how to add more data" demonstration
 
-  - method void Quit()
-    - terminates daemon
-    - debug feature, to be removed
+Autogenerated D-Bus autostart configuration
+-------------------------------------------
+
+  - stored under /run/user/UID/dbus-1/services
+  - for each application that defines:
+        - OrganizationName
+        - ApplicationName
+        - ExecDBus
+  - when application configuration data is installed / updated / removed
+    or current user changes, D-Bus activation configuration files are updated
+    accordingly and SessionBus daemon (for current user) is instructed to
+    reload configuration
 
 Internal Structure
-==================
+------------------
 
 - names below map directly to source files
 - also used in architecture graph
@@ -144,18 +250,14 @@ Internal Structure
       - APPLICATION SETTINGS: allowed/granted properties
   - SERVICE: dbus service, incoming method calls, outgoing signals
     - PROMPTER: session bus connection, queue/execute window prompt ipc
+  - MIGRATOR: migrates approval files from older sailjail versions
+    - APPROVAL: approval data from older sailjail versions
+  - APPSERVICES: maintaining autogenerated D-Bus activation configuration
 
 Directories Used
-================
+----------------
 
 - CONFIG:       "/etc/sailjail/config"
 - PERMISSIONS:  "/etc/sailjail/permissions"
-- APPLICATIONS: "/usr/share/applications"
+- APPLICATIONS: "/usr/share/applications" and "/etc/sailjail/applications"
 - SETTINGS:     "/home/.system/var/lib/sailjail/settings"
-
-What Is Missing
-===============
-
-- user prompting
-  - does asynchronous call to window prompt service
-    - but does not handle cancellation yet

--- a/daemon/appinfo.c
+++ b/daemon/appinfo.c
@@ -122,11 +122,11 @@ gchar       *appinfo_to_string (const appinfo_t *self);
  * APPINFO_ATTRIBUTE
  * ------------------------------------------------------------------------- */
 
-bool            appinfo_valid       (const appinfo_t *self);
-control_t      *appinfo_control     (const appinfo_t *self);
-const config_t *appinfo_config      (const appinfo_t *self);
-applications_t *appinfo_applications(const appinfo_t *self);
-const gchar    *appinfo_id          (const appinfo_t *self);
+bool            appinfo_valid          (const appinfo_t *self);
+control_t      *appinfo_control        (const appinfo_t *self);
+const config_t *appinfo_config         (const appinfo_t *self);
+applications_t *appinfo_applications   (const appinfo_t *self);
+const gchar    *appinfo_id             (const appinfo_t *self);
 bool            appinfo_dbus_auto_start(const appinfo_t *self);
 
 /* ------------------------------------------------------------------------- *
@@ -179,10 +179,10 @@ void         appinfo_clear_permissions   (appinfo_t *self);
  * APPINFO_PARSE
  * ------------------------------------------------------------------------- */
 
-static appinfo_file_t appinfo_combined_file_state    (appinfo_file_t state1, appinfo_file_t state2);
-static appinfo_file_t appinfo_check_desktop_from_path(appinfo_t *self, const gchar *path, appinfo_dir_t dir);
-bool                  appinfo_parse_desktop          (appinfo_t *self);
-static gchar         *appinfo_read_exec_dbus         (appinfo_t *self, GKeyFile *ini, const gchar *group);
+static appinfo_file_t  appinfo_combined_file_state    (appinfo_file_t state1, appinfo_file_t state2);
+static appinfo_file_t  appinfo_check_desktop_from_path(appinfo_t *self, const gchar *path, appinfo_dir_t dir);
+bool                   appinfo_parse_desktop          (appinfo_t *self);
+static gchar          *appinfo_read_exec_dbus         (appinfo_t *self, GKeyFile *ini, const gchar *group);
 
 /* ========================================================================= *
  * APPINFO
@@ -458,7 +458,6 @@ appinfo_id(const appinfo_t *self)
 {
     return self->anf_appname;
 }
-
 
 bool
 appinfo_dbus_auto_start(const appinfo_t *self)
@@ -984,14 +983,14 @@ EXIT:
     return appinfo_clear_dirty(self);
 }
 
-gchar *
+static gchar *
 appinfo_read_exec_dbus(appinfo_t *self, GKeyFile *ini, const gchar *group)
 {
     gchar *exec = keyfile_get_string(ini, group, SAILJAIL_KEY_EXEC_DBUS, 0);
     if( exec ) {
         /* As in libcontentaction, add invoker to the command line if it doesn't exist already. */
         if( g_strstr_len(exec, -1, "invoker") != exec &&
-                g_strstr_len(exec, -1, "/usr/bin/invoker") != exec) {
+            g_strstr_len(exec, -1, "/usr/bin/invoker") != exec ) {
             gchar *booster = keyfile_get_string(ini, DESKTOP_SECTION,
                     NEMO_KEY_APPLICATION_TYPE, NULL);
             if( booster == NULL || g_strcmp0(booster, "no-invoker") == 0 ) {

--- a/daemon/appinfo.h
+++ b/daemon/appinfo.h
@@ -80,11 +80,11 @@ gchar     *appinfo_to_string (const appinfo_t *self);
  * APPINFO_ATTRIBUTE
  * ------------------------------------------------------------------------- */
 
-bool            appinfo_valid       (const appinfo_t *self);
-control_t      *appinfo_control     (const appinfo_t *self);
-const config_t *appinfo_config      (const appinfo_t *self);
-applications_t *appinfo_applications(const appinfo_t *self);
-const gchar    *appinfo_id          (const appinfo_t *self);
+bool            appinfo_valid          (const appinfo_t *self);
+control_t      *appinfo_control        (const appinfo_t *self);
+const config_t *appinfo_config         (const appinfo_t *self);
+applications_t *appinfo_applications   (const appinfo_t *self);
+const gchar    *appinfo_id             (const appinfo_t *self);
 bool            appinfo_dbus_auto_start(const appinfo_t *self);
 
 /* ------------------------------------------------------------------------- *

--- a/daemon/appservices.c
+++ b/daemon/appservices.c
@@ -86,7 +86,6 @@ static char *appservices_service_filename     (appservices_t *self, const char *
 static void  appservices_write_service_file   (appservices_t *self, const char *appname, appinfo_t *appinfo);
 static void  appservices_remove_service_file  (appservices_t *self, const char *appname);
 
-
 /* ------------------------------------------------------------------------- *
  * SERVICEINFO
  * ------------------------------------------------------------------------- */
@@ -309,9 +308,9 @@ appservices_update_user(appservices_t *self)
         /* Verify the dbus services directory exists under run and create it if necessary
            Note the default directory ownership is incorrect in this instance and needs to
            be corrected for each subdirectory created */
-        if( self->asv_run_dir && (
-                    !appservices_ensure_run_directory(self, DBUS_DIRECTORY) ||
-                    !appservices_ensure_run_directory(self, DBUS_SERVICES_DIRECTORY))) {
+        if( self->asv_run_dir &&
+            (!appservices_ensure_run_directory(self, DBUS_DIRECTORY) ||
+             !appservices_ensure_run_directory(self, DBUS_SERVICES_DIRECTORY)) ) {
             g_free(self->asv_run_dir);
             self->asv_run_dir = NULL;
         }
@@ -376,7 +375,7 @@ appservices_write_service_file(appservices_t *self, const char *appname, appinfo
         changed = true;
     }
     /* If the existing name and executable are unchanged do nothing */
-    else if( current_service && !strcmp(exec, current_service->exec)) {
+    else if( current_service && !strcmp(exec, current_service->exec) ) {
         g_free(service_name);
 
         return;

--- a/daemon/control.c
+++ b/daemon/control.c
@@ -104,6 +104,7 @@ void control_on_session_changed   (control_t *self);
 void control_on_permissions_change(control_t *self);
 void control_on_application_change(control_t *self, GHashTable *changed);
 void control_on_settings_change   (control_t *self, const char *app);
+void control_on_appservices_change(control_t *self);
 
 /* ------------------------------------------------------------------------- *
  * CONTROL_RETHINK

--- a/daemon/prompter.c
+++ b/daemon/prompter.c
@@ -141,7 +141,7 @@ static void                   prompter_prompt_invocation_cb (GObject *obj, GAsyn
 static GVariant              *prompter_invocation_args      (const prompter_t *self, appinfo_t *appinfo);
 static bool                   prompter_prompt_invocation    (prompter_t *self);
 void                          prompter_handle_invocation    (prompter_t *self, GDBusMethodInvocation *invocation);
-void                          prompter_dbus_reload_config(prompter_t *self);
+void                          prompter_dbus_reload_config   (prompter_t *self);
 
 /* ------------------------------------------------------------------------- *
  * PROMPTER_RETURN
@@ -165,11 +165,11 @@ static GList                 *prompter_drop       (prompter_t *self, GList *iter
  * PROMPTER_CONNECTION
  * ------------------------------------------------------------------------- */
 
-static GDBusConnection *prompter_connection          (const prompter_t *self);
-static bool             prompter_is_connected        (const prompter_t *self);
-static bool             prompter_connect             (prompter_t *self);
-static void             prompter_disconnect          (prompter_t *self);
-static void             prompter_disconnect_flush_cb (GObject *obj, GAsyncResult *res, gpointer aptr);
+static GDBusConnection *prompter_connection         (const prompter_t *self);
+static bool             prompter_is_connected       (const prompter_t *self);
+static bool             prompter_connect            (prompter_t *self);
+static void             prompter_disconnect         (prompter_t *self);
+static void             prompter_disconnect_flush_cb(GObject *obj, GAsyncResult *res, gpointer aptr);
 
 /* ========================================================================= *
  * UTILITY

--- a/daemon/sailjaild.dot
+++ b/daemon/sailjaild.dot
@@ -28,11 +28,13 @@ digraph foo {
   USERS;
   APPLICATIONS;
   APPINFO;
+  APPSERVICES;
   PERMISSIONS;
   SESSION;
   WINDOW_PROMPT         [label=" Permission\l Dialog in\l SessionBus\l"]
   ANY                   [label=" (any)\l"]
   DBUS_CLIENT           [label=" D-Bus\l client in\l SystemBus\l"]
+  SESSION_BUS           [label=" SessionBus\l daemon\l"]
 
   /* - - - - - - - - - - - - - - - - - - - *
    * DATASTORES
@@ -52,6 +54,7 @@ digraph foo {
   REMOVAL_QUEUE         [label=" removal\l queue\l"]
   APPROVAL_FILES        [label=" /var/lib/sailjail-homescreen/**/\l APPLICATION.desktop/X-Sailjail\l"]
   SESSION_STATE         [label=" /run/systemd/\l sessions\l"];
+  ACTIVATION_FILES      [label=" /run/user/UID/dbus-1/services/\l DBUSNAME.service\l"]
 
   /* - - - - - - - - - - - - - - - - - - - *
    * DATAFLOWS (SYNC)
@@ -112,6 +115,7 @@ digraph foo {
   APPLICATIONS -> APPINFO         [label=" update\l"];
   APPINFO -> DESKTOP_FILES        [label=" read\l"];
   APPLICATIONS -> DESKTOP_FILES   [label=" scan\l"];
+  APPSERVICES -> ACTIVATION_FILES [label=" read\l write\l remove\l"];
 
   /* - - - - - - - - - - - - - - - - - - - *
    * DATAFLOWS (ASYNC)
@@ -146,4 +150,10 @@ digraph foo {
   SESSION_STATE -> SESSION        [label=" inotify\l"]
 
   SETTINGS -> CONTROL             [label=" changed\l"];
+
+  CONTROL -> APPSERVICES          [label=" applications\l changed\l"];
+  APPSERVICES -> CONTROL          [label=" activation\l changed\l"];
+
+  CONTROL -> PROMPTER             [label=" activation\l changed\l"];
+  PROMPTER -> SESSION_BUS         [label=" ReloadConfig\l"];
 }


### PR DESCRIPTION
Add section describing what kinds of clients sailjail daemon is serving
and what kinds of IPC methods they are expected to use/need.

Update / remove out-of-date information.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>