### PR TITLE
[sailjaild] Add dynamic list for granted applications. JB#55283 OMP#OS-8172

### DIFF
--- a/daemon/conf/user-grantlist.conf
+++ b/daemon/conf/user-grantlist.conf
@@ -1,0 +1,1 @@
+[Grantlist]

--- a/daemon/service.h
+++ b/daemon/service.h
@@ -74,6 +74,7 @@ G_BEGIN_DECLS;
 # define PERMISSIONMGR_METHOD_SET_LAUNCHABLE   "SetLaunchAllowed"
 # define PERMISSIONMGR_METHOD_GET_GRANTED      "GetGrantedPermissions"
 # define PERMISSIONMGR_METHOD_SET_GRANTED      "SetGrantedPermissions"
+# define PERMISSIONMGR_METHOD_SET_X_GRANTED    "SetGrantedXPermissions"
 # define PERMISSIONMGR_SIGNAL_APP_ADDED        "ApplicationAdded"
 # define PERMISSIONMGR_SIGNAL_APP_CHANGED      "ApplicationChanged"
 # define PERMISSIONMGR_SIGNAL_APP_REMOVED      "ApplicationRemoved"

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -83,6 +83,9 @@ ln -s ../sailjaild.service %{buildroot}%{_unitdir}/multi-user.target.wants/
 install -d %{buildroot}%{_sysconfdir}/sailjail/config
 install -d %{buildroot}%{_sysconfdir}/sailjail/applications
 
+install -D -m755 daemon/conf/user-grantlist.conf \
+        %{buildroot}%{_sysconfdir}/sailjail/config
+
 %files
 %defattr(-,root,root,-)
 %license COPYING
@@ -102,6 +105,7 @@ install -d %{buildroot}%{_sysconfdir}/sailjail/applications
 %dir %{_sysconfdir}/sailjail
 %dir %{_sysconfdir}/sailjail/config
 %dir %{_sysconfdir}/sailjail/applications
+%{_sysconfdir}/sailjail/config/user-grantlist.conf
 
 %files daemon-tests
 %defattr(-,root,root,-)


### PR DESCRIPTION
We can upload custom configuration files such as 50-mdm-allowlist.conf to sailjail.
But the issue is that it wont update\reload configurations on user switch, only on reboot.
It can be usefull to allow it to restart\start configuration updating on user switch, too.