### PR TITLE
[dbus] Allow identification of clients behind xdg-dbus-proxy

### DIFF
--- a/daemon/dbus/sailjaild.conf
+++ b/daemon/dbus/sailjaild.conf
@@ -17,4 +17,10 @@
 		<allow send_destination="org.sailfishos.sailjaild1"
 		       send_interface="org.sailfishos.sailjaild1"/>
 	</policy>
+	<!-- Allow xdg-dbus-proxy client Identify() queries -->
+	<policy context="default">
+		<allow send_destination="*"
+		       send_interface="org.sailfishos.sailjailed"
+		       send_member="Identify"/>
+	</policy>
 </busconfig>


### PR DESCRIPTION
In case of sandboxed applications GetConnectionUnixProcessID returns
pid of xdg-dbus-proxy process rather than pid of the actual client.

In Sailfish OS xdg-dbus-proxy implements an D-Bus interface that can
be used for identifying clients behind the proxy.

Allow such queries to be made.

Signed-off-by: Simo Piiroinen <simo.piiroinen@jolla.com>