### PR TITLE
[tests] Fix tests depending on BINDIR. Fixes JB#56961

### DIFF
--- a/daemon/test/meson.build
+++ b/daemon/test/meson.build
@@ -39,7 +39,7 @@ custom_target('tests.xml',
 	'-e', 's|@TESTSDIR@|' + testsdir + '|g',
 	'-e', 's|@TESTDATADIR@|' + testdatadir + '|g',
 	'-e', 's|@SHAREDSTATEDIR@|' + tests_sharedstatedir + '|g',
-	'-e', 's|@BINDIR@|' + tests_bindir + '|g',
+	'-e', 's|@TESTBINDIR@|' + tests_bindir + '|g',
 	'@INPUT@'],
   install : true,
   install_dir : testsdir)
@@ -61,7 +61,6 @@ create_permission_files = custom_target('permissions',
 # Tests for QA
 # ----------------------------------------------------------------------------
 test_options = [
-    '-DBINDIR="' + tests_bindir + '"',
     '-DSYSCONFDIR="' + tests_sysconfdir + '"',
     '-DSHAREDSTATEDIR="' + tests_sharedstatedir + '"',
     '-DDATADIR="' + tests_datadir + '"',

--- a/daemon/test/tests.xml.in
+++ b/daemon/test/tests.xml.in
@@ -12,31 +12,31 @@
                <step>cp -r @TESTSDIR@/etc @TESTTMPDATA@/etc</step>
            </pre_steps>
            <case name="util strip" level="Component" type="Functional">
-               <step>@BINDIR@/test_util -p "/sailjaild/util/strip"</step>
+               <step>@TESTBINDIR@/test_util -p "/sailjaild/util/strip"</step>
            </case>
            <case name="util path" level="Component" type="Functional">
-               <step>@BINDIR@/test_util -p "/sailjaild/util/path"</step>
+               <step>@TESTBINDIR@/test_util -p "/sailjaild/util/path"</step>
            </case>
            <case name="util change" level="Component" type="Functional">
-               <step>@BINDIR@/test_util -p "/sailjaild/util/change"</step>
+               <step>@TESTBINDIR@/test_util -p "/sailjaild/util/change"</step>
            </case>
            <case name="util keyfile" level="Component" type="Functional">
-               <step>@BINDIR@/test_util -p "/sailjaild/util/keyfile"</step>
+               <step>@TESTBINDIR@/test_util -p "/sailjaild/util/keyfile"</step>
            </case>
            <case name="stringset" level="Component" type="Functional">
-               <step>@BINDIR@/test_stringset</step>
+               <step>@TESTBINDIR@/test_stringset</step>
            </case>
            <case name="appinfo" level="Component" type="Functional">
-               <step>@BINDIR@/test_appinfo</step>
+               <step>@TESTBINDIR@/test_appinfo</step>
            </case>
            <case name="permissions" level="Component" type="Functional">
-               <step>@BINDIR@/test_permissions</step>
+               <step>@TESTBINDIR@/test_permissions</step>
            </case>
            <case name="settings" level="Component" type="Functional">
-               <step>@BINDIR@/test_settings -p /sailjaild/settings/settings</step>
+               <step>@TESTBINDIR@/test_settings -p /sailjaild/settings/settings</step>
            </case>
            <case name="sailjailclient" level="Component" type="Functional">
-               <step>@BINDIR@/test_sailjailclient -p /sailjaild/sailjailclient</step>
+               <step>@TESTBINDIR@/test_sailjailclient -p /sailjaild/sailjailclient</step>
            </case>
            <post_steps>
                <step>rm -rf @TESTTMPDATA@</step>


### PR DESCRIPTION
Some tests expect that BINDIR points to /usr/bin which makes sense,
however in QA tests it was overridden to point to elsewhere and that
made some tests fail. Local unittests didn't redefine that. Avoid
redefining BINDIR as it's not necessary and also rename that BINDIR in
tests.xml.in to TESTBINDIR to avoid confusion.