### PR TITLE
[sailjail] Obsolete sailjail-homescreen-plugin. Fixes JB#54821

### DIFF
--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -15,6 +15,9 @@ Requires(pre): sailfish-setup
 
 Requires: glib2 >= %{glib_version}
 Requires: sailjail-daemon
+Provides: sailjail-launch-approval
+# This can be removed after next stop release after 4.4.0.
+Obsoletes: sailjail-homescreen-plugin <= 1.1.0
 
 BuildRequires: meson
 BuildRequires: pkgconfig(glib-2.0) >= %{glib_version}


### PR DESCRIPTION
The sailjail-homescreen-plugin obsolete line can be removed
after next stop release.