### PR TITLE
Expose app mode for mode-specific permission prompts

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -263,3 +263,31 @@ Directories Used
 - PERMISSIONS:  "/etc/sailjail/permissions"
 - APPLICATIONS: "/usr/share/applications" and "/etc/sailjail/applications"
 - SETTINGS:     "/home/.system/var/lib/sailjail/settings"
+
+Allowlisting system applications
+--------------------------------
+
+Applications that are part of the core system may be configured so that the
+user is never prompted about their permissions. Allowlist configuration is
+read from drop-in files under `/etc/sailjail/config/*.conf`. Distribution
+packages may provide files such as `50-sailfish-allowlist.conf` with an
+`[Allowlist]` section where keys are desktop file stems
+(for example `jolla-settings`) and values select the behaviour:
+
+* `default` – normal prompting rules apply
+* `always` – the application is automatically granted all permissions
+* `launch` – application launch is automatically allowed, but user settings
+  still control individual permissions
+
+Additional entries can be added via further drop-in files under
+`/etc/sailjail/config/*.conf`.
+
+Prompting applications with Sandboxing=Disabled
+-----------------------------------------------
+
+Applications that set `Sandboxing=Disabled` in their desktop file now show a
+single warning prompt the first time they are launched via Sailjail.  This
+warning explains that the application runs outside the sandbox.  Once the user
+accepts the warning the decision is remembered in
+`/home/.system/var/lib/sailjail/settings/user-UID.settings` and no further
+prompts are shown unless the settings file is cleared.

--- a/daemon/appinfo.c
+++ b/daemon/appinfo.c
@@ -150,7 +150,7 @@ const gchar            *appinfo_get_application_name (const appinfo_t *self);
 const gchar            *appinfo_get_exec_dbus        (const appinfo_t *self);
 const gchar            *appinfo_get_data_directory   (const appinfo_t *self);
 app_mode_t              appinfo_get_mode             (const appinfo_t *self);
-static const gchar     *appinfo_get_mode_string      (const appinfo_t *self);
+const gchar            *appinfo_get_mode_name        (const appinfo_t *self);
 void                    appinfo_set_name             (appinfo_t *self, const gchar *name);
 void                    appinfo_set_type             (appinfo_t *self, const gchar *type);
 void                    appinfo_set_icon             (appinfo_t *self, const gchar *icon);
@@ -387,7 +387,7 @@ appinfo_to_variant(const appinfo_t *self)
 
     if( self ) {
         add_string("Id", appinfo_id(self));
-        add_string("Mode", appinfo_get_mode_string(self));
+        add_string("Mode", appinfo_get_mode_name(self));
 
         /* Desktop properties
          */
@@ -592,15 +592,20 @@ appinfo_get_mode(const appinfo_t *self)
     return self->anf_mode;
 }
 
-static const gchar *
-appinfo_get_mode_string(const appinfo_t *self)
+const gchar *
+appinfo_get_mode_name(const appinfo_t *self)
 {
-    static const gchar * const lut[] = {
+    static const gchar * const mode_names[] = {
         [APP_MODE_NORMAL]        = "Normal",
         [APP_MODE_COMPATIBILITY] = "Compatibility",
         [APP_MODE_NONE]          = "None",
     };
-    return lut[self->anf_mode];
+    app_mode_t mode = appinfo_get_mode(self);
+
+    if( mode < APP_MODE_NORMAL || (size_t)mode >= G_N_ELEMENTS(mode_names) )
+        mode = APP_MODE_NORMAL;
+
+    return mode_names[mode];
 }
 
 /* - - - - - - - - - - - - - - - - - - - *
@@ -922,8 +927,9 @@ appinfo_parse_desktop(appinfo_t *self)
         group = SAILJAIL_SECTION_SECONDARY;
     /* else: legacy app => use default profile */
 
-    /* Sandboxing=Disabled means that the app opts out of sandboxing and
-     * launching via sailjail will result in use of compatibility mode.
+    /* Sandboxing=Disabled means that the app opts out of sandboxing.
+     * The daemon keeps such apps in APP_MODE_NONE so higher layers can
+     * show the warning-only launch prompt.
      */
     gchar *sandboxing = NULL;
     if( group )
@@ -954,17 +960,22 @@ appinfo_parse_desktop(appinfo_t *self)
     else {
         /* Read default profile from configuration */
         const config_t *config = appinfo_config(self);
-        set = config_stringset(config,
-                               APPINFO_DEFAULT_PROFILE_SECTION,
-                               SAILJAIL_KEY_PERMISSIONS);
+        bool default_profile_enabled =
+            config_boolean(config,
+                           APPINFO_DEFAULT_PROFILE_SECTION,
+                           APPINFO_KEY_ENABLED, false);
         if( !g_strcmp0(sandboxing, "Disabled") ||
-            !config_boolean(config,
-                            APPINFO_DEFAULT_PROFILE_SECTION,
-                            APPINFO_KEY_ENABLED, false) ||
-            needs_exclusion_from_sandboxing(appinfo_get_exec(self)) )
+            !default_profile_enabled ||
+            needs_exclusion_from_sandboxing(appinfo_get_exec(self)) ) {
+            set = stringset_create();
             appinfo_set_mode(self, APP_MODE_NONE);
-        else
+        }
+        else {
+            set = config_stringset(config,
+                                   APPINFO_DEFAULT_PROFILE_SECTION,
+                                   SAILJAIL_KEY_PERMISSIONS);
             appinfo_set_mode(self, APP_MODE_COMPATIBILITY);
+        }
     }
     appinfo_set_permissions(self, set);
     stringset_delete(set);
@@ -1026,9 +1037,6 @@ appinfo_read_exec_dbus(appinfo_t *self, GKeyFile *ini, const gchar *group)
     return exec;
 }
 
-/* ------------------------------------------------------------------------- *
- * UTILS
- * ------------------------------------------------------------------------- */
 static bool
 needs_exclusion_from_sandboxing(const gchar *exec)
 {

--- a/daemon/appinfo.h
+++ b/daemon/appinfo.h
@@ -104,6 +104,7 @@ const gchar *appinfo_get_application_name (const appinfo_t *self);
 const gchar *appinfo_get_exec_dbus        (const appinfo_t *self);
 const gchar *appinfo_get_data_directory   (const appinfo_t *self);
 app_mode_t   appinfo_get_mode             (const appinfo_t *self);
+const gchar *appinfo_get_mode_name        (const appinfo_t *self);
 void         appinfo_set_name             (appinfo_t *self, const gchar *name);
 void         appinfo_set_type             (appinfo_t *self, const gchar *type);
 void         appinfo_set_icon             (appinfo_t *self, const gchar *icon);

--- a/daemon/prompter.c
+++ b/daemon/prompter.c
@@ -66,6 +66,9 @@ typedef enum prompter_state_t {
     PROMPTER_STATE_FINAL
 } prompter_state_t;
 
+#define WINDOWPROMPT_KEY_REQUIRED "required"
+#define WINDOWPROMPT_KEY_MODE     "mode"
+
 /* ========================================================================= *
  * Prototypes
  * ========================================================================= */
@@ -998,8 +1001,11 @@ prompter_invocation_args(const prompter_t *self, appinfo_t *appinfo)
         vector[i] = path_from_permission_name(perm);
         g_free(perm);
     }
-    g_variant_builder_add(&builder, "{s^as}", "required", vector);
+    g_variant_builder_add(&builder, "{s^as}", WINDOWPROMPT_KEY_REQUIRED, vector);
     g_strfreev(vector);
+    const gchar *mode = appinfo_get_mode_name(appinfo);
+    const gchar *mode_vector[] = { mode, NULL };
+    g_variant_builder_add(&builder, "{s^as}", WINDOWPROMPT_KEY_MODE, mode_vector);
 
     args = g_variant_new("(s@a{sas})", desktop, g_variant_builder_end(&builder));
 

--- a/daemon/service.c
+++ b/daemon/service.c
@@ -894,7 +894,11 @@ service_dbus_call_cb(GDBusConnection       *connection,
             const stringset_t *permissions = appinfo_get_permissions(appinfo);
             stringset_t *filtered = service_filter_permissions(self,
                                                                permissions);
-            if( stringset_empty(filtered) ) {
+            /* Empty permission sets are auto-allowed, except for Mode=None
+             * apps, which still need the warning-only prompt.
+             */
+            if( stringset_empty(filtered) &&
+                appinfo_get_mode(appinfo) != APP_MODE_NONE ) {
                 if( appsettings_get_allowed(appsettings) == APP_ALLOWED_UNSET )
                     appsettings_set_allowed(appsettings, APP_ALLOWED_ALWAYS);
             }

--- a/daemon/settings.c
+++ b/daemon/settings.c
@@ -226,6 +226,8 @@ static void appsettings_notify_change   (appsettings_t *self);
 app_agreed_t              appsettings_get_agreed        (const appsettings_t *self);
 static bool               appsettings_update_agreed     (appsettings_t *self, app_agreed_t agreed);
 void                      appsettings_set_agreed        (appsettings_t *self, app_agreed_t agreed);
+static app_mode_t         appsettings_get_current_mode  (const appsettings_t *self);
+static bool               appsettings_update_current_mode(appsettings_t *self, app_mode_t mode);
 static const stringset_t *appsettings_get_permissions   (const appsettings_t *self);
 static int                appsettings_update_permissions(appsettings_t *self, stringset_t *added);
 static app_grant_t        appsettings_get_autogrant     (const appsettings_t *self);
@@ -808,6 +810,7 @@ struct appsettings_t
     app_allowed_t   ast_allowed;
     app_grant_t     ast_autogrant;
     app_agreed_t    ast_agreed;
+    app_mode_t      ast_mode;
     stringset_t    *ast_granted;
     stringset_t    *ast_permissions;
 };
@@ -822,6 +825,7 @@ appsettings_ctor(appsettings_t *self, usersettings_t *usersettings,
     self->ast_allowed      = APP_ALLOWED_UNSET;
     self->ast_autogrant    = APP_GRANT_DEFAULT;
     self->ast_agreed       = APP_AGREED_UNSET;
+    self->ast_mode         = APP_MODE_NORMAL;
     self->ast_granted      = stringset_create();
     self->ast_permissions  = stringset_create();
 
@@ -970,6 +974,44 @@ void
 appsettings_set_agreed(appsettings_t *self, app_agreed_t agreed)
 {
     appsettings_update_agreed(self, agreed);
+}
+
+static app_mode_t
+appsettings_get_current_mode(const appsettings_t *self)
+{
+    app_mode_t mode = APP_MODE_NORMAL;
+
+    appinfo_t *appinfo = control_appinfo(appsettings_control(self),
+                                         appsettings_appname(self));
+    if( appinfo )
+        mode = appinfo_get_mode(appinfo);
+
+    return mode;
+}
+
+static bool
+appsettings_update_current_mode(appsettings_t *self, app_mode_t mode)
+{
+    bool changed = false;
+
+    if( mode < APP_MODE_NORMAL || mode > APP_MODE_NONE )
+        mode = APP_MODE_NORMAL;
+
+    if( self->ast_mode != mode ) {
+        log_info("%s(uid=%d): mode: %d -> %d",
+                 appsettings_appname(self),
+                 appsettings_uid(self),
+                 self->ast_mode,
+                 mode);
+        self->ast_mode = mode;
+        changed = true;
+    }
+
+    /* Note: mode is internal cache -> no D-Bus notifications */
+    if( changed )
+        appsettings_notify_change_ex(self, false);
+
+    return changed;
 }
 
 static const stringset_t *
@@ -1179,6 +1221,13 @@ appsettings_decode(appsettings_t *self, GKeyFile *file)
                                             APP_AGREED_UNSET);
     self->ast_autogrant = keyfile_get_integer(file, sec, "Autogrant",
                                               APP_GRANT_DEFAULT);
+    if( g_key_file_has_key(file, sec, "Mode", NULL) ) {
+        self->ast_mode = keyfile_get_integer(file, sec, "Mode",
+                                             APP_MODE_NORMAL);
+    }
+    else {
+        self->ast_mode = APP_MODE_NORMAL;
+    }
 
     stringset_delete_at(&self->ast_permissions);
     self->ast_permissions = keyfile_get_stringset(file, sec, "Permissions");
@@ -1197,6 +1246,7 @@ appsettings_encode(const appsettings_t *self, GKeyFile *file)
     keyfile_set_integer(file, sec, "Allowed", self->ast_allowed);
     keyfile_set_integer(file, sec, "Agreed", self->ast_agreed);
     keyfile_set_integer(file, sec, "Autogrant", self->ast_autogrant);
+    keyfile_set_integer(file, sec, "Mode", self->ast_mode);
     keyfile_set_stringset(file, sec, "Granted", self->ast_granted);
     keyfile_set_stringset(file, sec, "Permissions", self->ast_permissions);
 }
@@ -1214,9 +1264,16 @@ appsettings_rethink(appsettings_t *self)
 
     stringset_t *added = stringset_create();
     int permission_change = appsettings_update_permissions(self, added);
+    bool mode_change =
+        appsettings_update_current_mode(self, appsettings_get_current_mode(self));
 
     const stringset_t *permissions = appsettings_get_permissions(self);
     const stringset_t *granted = appsettings_get_granted(self);
+
+    if( mode_change ) {
+        if( appsettings_get_allowed(self) != APP_ALLOWED_NEVER )
+            appsettings_update_allowed(self, APP_ALLOWED_UNSET);
+    }
 
     if( appsettings_update_autogrant(self, appsettings_get_allowlisted(self)) ) {
         /* Autogrant config changed: choose all or nothing */
@@ -1267,6 +1324,7 @@ appsettings_get_allowlisted(const appsettings_t *self)
                                        APP_CONFIG_ALLOWLIST,
                                        appsettings_appname(self),
                                        app_grant_name[APP_GRANT_DEFAULT]);
+
     for( app_grant_t grant = 0; grant < APP_GRANT_COUNT; ++grant ) {
         if( !strcmp(conf, app_grant_name[grant]) ) {
             value = grant;

--- a/daemon/test/sailjail/applications/default-app.desktop
+++ b/daemon/test/sailjail/applications/default-app.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Default Application
+Type=Application
+Icon=test
+Exec=/usr/bin/true

--- a/daemon/test/sailjail/applications/disabled-app.desktop
+++ b/daemon/test/sailjail/applications/disabled-app.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Disabled Application
+Type=Application
+Icon=test
+Exec=/usr/bin/true
+
+[X-Sailjail]
+Sandboxing=Disabled

--- a/daemon/test/test_appinfo.c
+++ b/daemon/test/test_appinfo.c
@@ -94,17 +94,20 @@ stringset_t *
 __wrap_config_stringset(config_t *self, const gchar *sec, const gchar *key)
 {
     (void)self; // unused
-    (void)sec; // unused
-    (void)key; // unused
-    return stringset_create();
+    stringset_t *set = stringset_create();
+    if( !g_strcmp0(sec, "Default Profile") &&
+        !g_strcmp0(key, "Permissions") )
+        stringset_add_item(set, "Internet");
+    return set;
 }
 
 bool
 __wrap_config_boolean(config_t *self, const gchar *sec, const gchar *key, bool def)
 {
     (void)self; // unused
-    (void)sec; // unused
-    (void)key; // unused
+    if( !g_strcmp0(sec, "Default Profile") &&
+        !g_strcmp0(key, "Enabled") )
+        return true;
     return def;
 }
 
@@ -184,6 +187,28 @@ void test_appinfo_exec(gconstpointer user_data)
     appinfo_delete(appinfo);
 }
 
+void test_appinfo_compatibility_mode(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "default-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_true(appinfo_valid(appinfo));
+    g_assert_cmpint(appinfo_get_mode(appinfo), ==, APP_MODE_COMPATIBILITY);
+    g_assert_true(appinfo_has_permission(appinfo, "Internet"));
+    appinfo_delete(appinfo);
+}
+
+void test_appinfo_disabled_mode(gconstpointer user_data)
+{
+    appinfo_t *appinfo = appinfo_create((applications_t *)user_data, "disabled-app");
+    g_assert_nonnull(appinfo);
+    g_assert_true(appinfo_parse_desktop(appinfo));
+    g_assert_true(appinfo_valid(appinfo));
+    g_assert_cmpint(appinfo_get_mode(appinfo), ==, APP_MODE_NONE);
+    g_assert_cmpint(stringset_size(appinfo_get_permissions(appinfo)), ==, 0);
+    appinfo_delete(appinfo);
+}
+
 /* ========================================================================= *
  * MAIN
  * ========================================================================= */
@@ -202,6 +227,8 @@ int main(int argc, char **argv)
     g_test_add_data_func("/sailjaild/appinfo/read_properties", &mock, test_appinfo_read_properties);
     g_test_add_data_func("/sailjaild/appinfo/permissions", &mock, test_appinfo_permissions);
     g_test_add_data_func("/sailjaild/appinfo/exec", &mock, test_appinfo_exec);
+    g_test_add_data_func("/sailjaild/appinfo/compatibility_mode", &mock, test_appinfo_compatibility_mode);
+    g_test_add_data_func("/sailjaild/appinfo/disabled_mode", &mock, test_appinfo_disabled_mode);
 
     return g_test_run();
 }

--- a/daemon/test/test_settings.c
+++ b/daemon/test/test_settings.c
@@ -51,6 +51,7 @@
 
 typedef struct {
     bool mck_guest_valid;
+    const gchar *mck_allowlist_value;
     stringset_t *mck_ctl_available_permissions;
     stringset_t *mck_ctl_valid_applications;
 } settings_test_mock_t;
@@ -59,12 +60,15 @@ void
 settings_test_mock_init(settings_test_mock_t *mock)
 {
     mock->mck_guest_valid = true;
+    mock->mck_allowlist_value = NULL;
     mock->mck_ctl_available_permissions = stringset_create();
     stringset_add_item(mock->mck_ctl_available_permissions, "Audio");
     stringset_add_item(mock->mck_ctl_available_permissions, "Internet");
     stringset_add_item(mock->mck_ctl_available_permissions, "Pictures");
     mock->mck_ctl_valid_applications = stringset_create();
     stringset_add_item(mock->mck_ctl_valid_applications, "test-app");
+    stringset_add_item(mock->mck_ctl_valid_applications, "default-app");
+    stringset_add_item(mock->mck_ctl_valid_applications, "disabled-app");
 }
 
 /* ========================================================================= *
@@ -138,9 +142,11 @@ __wrap_control_on_settings_change(control_t *self, const gchar *appname)
 gchar *
 __wrap_config_string(const config_t *self, const gchar *sec, const gchar *key, const gchar *def)
 {
-    (void)self; // unused
-    (void)sec; // unused
-    (void)key; // unused
+    const settings_test_mock_t *mock = (const settings_test_mock_t *)self;
+    if( mock->mck_allowlist_value &&
+        !g_strcmp0(sec, "Allowlist") &&
+        !g_strcmp0(key, "test-app") )
+        return g_strdup(mock->mck_allowlist_value);
     return g_strdup(def);
 }
 
@@ -148,18 +154,45 @@ stringset_t *
 __wrap_config_stringset(config_t *self, const gchar *sec, const gchar *key)
 {
     (void)self; // unused
-    (void)sec; // unused
-    (void)key; // unused
-    return stringset_create();
+    stringset_t *set = stringset_create();
+    if( !g_strcmp0(sec, "Default Profile") &&
+        !g_strcmp0(key, "Permissions") )
+        stringset_add_item(set, "Internet");
+    return set;
 }
 
 bool
 __wrap_config_boolean(config_t *self, const gchar *sec, const gchar *key, bool def)
 {
     (void)self; // unused
-    (void)sec; // unused
-    (void)key; // unused
+    if( !g_strcmp0(sec, "Default Profile") &&
+        !g_strcmp0(key, "Enabled") )
+        return true;
     return def;
+}
+
+static gchar *
+test_settings_user_path(void)
+{
+    return g_strdup_printf(SHAREDSTATEDIR "/sailjail/settings/user-1000.settings");
+}
+
+static void
+test_settings_write_user_data(const gchar *data)
+{
+    gchar *path = test_settings_user_path();
+    g_assert_true(g_file_set_contents(path, data, -1, NULL));
+    g_free(path);
+}
+
+static gchar *
+test_settings_read_user_data(void)
+{
+    gchar *path = test_settings_user_path();
+    gchar *data = NULL;
+    g_assert_true(g_file_get_contents(path, &data, NULL, NULL));
+    g_free(path);
+    return data;
 }
 
 /* ========================================================================= *
@@ -232,6 +265,85 @@ void test_settings_load(gconstpointer user_data)
     settings_delete(settings);
 }
 
+void test_settings_allowlist_launch(gconstpointer user_data)
+{
+    settings_test_mock_t *mock = (settings_test_mock_t *)user_data;
+    mock->mck_allowlist_value = "launch";
+
+    settings_t *settings = settings_create((config_t *)mock, (control_t *)mock);
+    g_assert_nonnull(settings);
+
+    appsettings_t *appsettings = settings_add_appsettings(settings, 1000, "test-app");
+    g_assert_nonnull(appsettings);
+    g_assert_cmpint(appsettings_get_allowed(appsettings), ==, APP_ALLOWED_ALWAYS);
+    g_assert_true(stringset_has_item(appsettings_get_granted(appsettings), "Internet"));
+
+    settings_delete(settings);
+    mock->mck_allowlist_value = NULL;
+}
+
+void test_settings_compatibility_permissions_persist(gconstpointer user_data)
+{
+    settings_t *settings = settings_create((config_t *)user_data, (control_t *)user_data);
+    g_assert_nonnull(settings);
+
+    appsettings_t *appsettings = settings_add_appsettings(settings, 1000, "default-app");
+    g_assert_nonnull(appsettings);
+
+    settings_save_user(settings, 1000);
+
+    gchar *data = test_settings_read_user_data();
+    g_assert_nonnull(g_strstr_len(data, -1, "[default-app]"));
+    g_assert_nonnull(g_strstr_len(data, -1, "Permissions=Internet"));
+    g_free(data);
+
+    settings_delete(settings);
+}
+
+void test_settings_mode_transition_compatibility(gconstpointer user_data)
+{
+    settings_t *settings = settings_create((config_t *)user_data, (control_t *)user_data);
+    g_assert_nonnull(settings);
+
+    test_settings_write_user_data(
+        "[default-app]\n"
+        "Allowed=1\n"
+        "Agreed=0\n"
+        "Autogrant=0\n"
+        "Granted=Internet\n"
+        "Permissions=Internet\n");
+
+    settings_load_user(settings, 1000);
+    appsettings_t *appsettings = settings_get_appsettings(settings, 1000, "default-app");
+    g_assert_nonnull(appsettings);
+    g_assert_cmpint(appsettings_get_allowed(appsettings), ==, APP_ALLOWED_UNSET);
+    g_assert_cmpint(stringset_size(appsettings_get_granted(appsettings)), ==, 0);
+
+    settings_delete(settings);
+}
+
+void test_settings_mode_transition_none(gconstpointer user_data)
+{
+    settings_t *settings = settings_create((config_t *)user_data, (control_t *)user_data);
+    g_assert_nonnull(settings);
+
+    test_settings_write_user_data(
+        "[disabled-app]\n"
+        "Allowed=1\n"
+        "Agreed=0\n"
+        "Autogrant=0\n"
+        "Granted=Internet\n"
+        "Permissions=Internet\n");
+
+    settings_load_user(settings, 1000);
+    appsettings_t *appsettings = settings_get_appsettings(settings, 1000, "disabled-app");
+    g_assert_nonnull(appsettings);
+    g_assert_cmpint(appsettings_get_allowed(appsettings), ==, APP_ALLOWED_UNSET);
+    g_assert_cmpint(stringset_size(appsettings_get_granted(appsettings)), ==, 0);
+
+    settings_delete(settings);
+}
+
 /* ========================================================================= *
  * MAIN
  * ========================================================================= */
@@ -247,6 +359,10 @@ int main(int argc, char **argv)
 
     g_test_add_data_func("/sailjaild/settings/settings/create_and_delete", &mock, test_settings_create_delete);
     g_test_add_data_func("/sailjaild/settings/settings/load", &mock, test_settings_load);
+    g_test_add_data_func("/sailjaild/settings/settings/allowlist_launch", &mock, test_settings_allowlist_launch);
+    g_test_add_data_func("/sailjaild/settings/settings/compatibility_permissions_persist", &mock, test_settings_compatibility_permissions_persist);
+    g_test_add_data_func("/sailjaild/settings/settings/mode_transition_compatibility", &mock, test_settings_mode_transition_compatibility);
+    g_test_add_data_func("/sailjaild/settings/settings/mode_transition_none", &mock, test_settings_mode_transition_none);
 
     return g_test_run();
 }

--- a/rpm/sailjail.spec
+++ b/rpm/sailjail.spec
@@ -74,6 +74,9 @@ Summary: QA tests for %{name}-daemon
 
 %meson_build
 
+%check
+%meson_test
+
 %install
 %meson_install
 


### PR DESCRIPTION
- Make app-mode a first-class app attribute and carry it through the approval path so the UI can present different prompts for apps using declared permissions, compatibility/default-profile sandboxing and no sandboxing.

- Persist the approved mode in user settings and clear launch approval when it changes, so apps are prompted again after moving between these modes. Treat APP_MODE_NONE as a warning-only prompt case instead of auto-allowing empty permission sets, while keeping compatibility-mode permissions stored.

- Update the daemon documentation, add test coverage for mode handling and settings migration, and run the Meson tests in %check.